### PR TITLE
Fix to typo in [IndexerLevel - Uneven Indexed Data Across The Indexers]

### DIFF
--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -967,7 +967,7 @@ request.ui_dispatch_view = search
 search = | tstats summariesonly=t count WHERE index="*" by splunk_server _time span=10m\
 | search `comment("If the balance of data between indexer cluster members becomes very unbalanced then the searches tend to spend more CPU on a particular indexer / search peer and this eventually creates issues")`\
 | sort _time \
-| eventstats sum(count) AS totalCountForTime, dc(splunk_servers) AS indexers by _time \
+| eventstats sum(count) AS totalCountForTime, dc(splunk_server) AS indexers by _time \
 | eval perc=round((count/totalCountForTime)*100,2) \
 | eval expectedShare = 100 / indexers\
 | eval perc = 100 - (expectedShare / perc)*100\


### PR DESCRIPTION
Minor fix.
Just noticed it here.
dc(splunk_servers) but field is splunk_server.