### PR TITLE
Replace comment macro with triple backticks

### DIFF
--- a/default/data/ui/views/data_model_rebuild_monitor.xml
+++ b/default/data/ui/views/data_model_rebuild_monitor.xml
@@ -150,9 +150,9 @@
       </single>
       <single>
         <search>
-          <query>`comment("The authors original attempt of | `datamodel(\"Splunk_Audit\", \"Datamodel_Acceleration\")` | `drop_dm_object_name(\"Datamodel_Acceleration\")` Just did not appear to show accurate numbers when compared to the filesystem of the indexers")`
-`comment("The previous attempt at this number via | rest \"/services/admin/introspection--disk-objects--summaries?count=-1\" ... worked fine *unless* there were multiple search head GUID's in the introspection data in which case it seems to return 1 set only (resulting in highly inaccurate numbers in some cases")`
-    `comment("Now querying the introspection data instead as that provides consistently accurate numbers")`
+          <query>```The authors original attempt of | `datamodel(\"Splunk_Audit\", \"Datamodel_Acceleration\``` | `drop_dm_object_name(\"Datamodel_Acceleration\")` Just did not appear to show accurate numbers when compared to the filesystem of the indexers")`
+```The previous attempt at this number via | rest \"/services/admin/introspection--disk-objects--summaries?count=-1\" ... worked fine *unless* there were multiple search head GUID's in the introspection data in which case it seems to return 1 set only (resulting in highly inaccurate numbers in some cases```
+    ```Now querying the introspection data instead as that provides consistently accurate numbers```
     index=_introspection `indexerhosts` component=summaries "data.name"=*$dm$
 | stats latest(data.total_size) AS size by data.search_head_guid, data.related_indexes_count, data.related_indexes, host
 | stats sum(size) AS size</query>

--- a/default/data/ui/views/data_model_rebuild_monitor.xml
+++ b/default/data/ui/views/data_model_rebuild_monitor.xml
@@ -150,9 +150,9 @@
       </single>
       <single>
         <search>
-          <query>```The authors original attempt of | `datamodel(\"Splunk_Audit\", \"Datamodel_Acceleration\``` | `drop_dm_object_name(\"Datamodel_Acceleration\")` Just did not appear to show accurate numbers when compared to the filesystem of the indexers")`
-```The previous attempt at this number via | rest \"/services/admin/introspection--disk-objects--summaries?count=-1\" ... worked fine *unless* there were multiple search head GUID's in the introspection data in which case it seems to return 1 set only (resulting in highly inaccurate numbers in some cases```
-    ```Now querying the introspection data instead as that provides consistently accurate numbers```
+          <query>```The authors original attempt of | `datamodel("Splunk_Audit", "Datamodel_Acceleration | `drop_dm_object_name("Datamodel_Acceleration")` Just did not appear to show accurate numbers when compared to the filesystem of the indexers 
+The previous attempt at this number via | rest "/services/admin/introspection--disk-objects--summaries?count=-1" ... worked fine *unless* there were multiple search head GUID's in the introspection data in which case it seems to return 1 set only (resulting in highly inaccurate numbers in some cases)
+    Now querying the introspection data instead as that provides consistently accurate numbers```
     index=_introspection `indexerhosts` component=summaries "data.name"=*$dm$
 | stats latest(data.total_size) AS size by data.search_head_guid, data.related_indexes_count, data.related_indexes, host
 | stats sum(size) AS size</query>

--- a/default/data/ui/views/issues_per_sourcetype.xml
+++ b/default/data/ui/views/issues_per_sourcetype.xml
@@ -19,17 +19,17 @@
       <table>
         <title>Timestamp parsing has failed, note that if the null queue is in use this can give false alarms</title>
         <search>
-          <query>```Timestamp parsing has failed, and it doesn't appear to be related to the event been broken due to having too many lines, that is a separate alert that may trigger a timestamp parsing issue (excluded from this alert as that issue needs to be resolved first)```
-```Please note that you may see this particular warning on data that is sent to the nullQueue using a transforms.conf. Obviously you won't see this in the index but you will see the warning because the time parsing occurs before the transforms.conf occurs```
-```This alert now checks for at least 2 failures, and header entries can often trigger 2 entries in the log files about timestamp parsing failures...```
-```Finally one strange edge case is a newline inserted into the log file (by itself with no content before/afterward) can trigger the warning but nothing will get indexed, multiline_event_extra_waittime, time_before_close and EVENT_BREAKER can resolve this edge case```
+          <query>```Timestamp parsing has failed, and it doesn't appear to be related to the event been broken due to having too many lines, that is a separate alert that may trigger a timestamp parsing issue (excluded from this alert as that issue needs to be resolved first)
+Please note that you may see this particular warning on data that is sent to the nullQueue using a transforms.conf. Obviously you won't see this in the index but you will see the warning because the time parsing occurs before the transforms.conf occurs
+This alert now checks for at least 2 failures, and header entries can often trigger 2 entries in the log files about timestamp parsing failures...
+Finally one strange edge case is a newline inserted into the log file (by itself with no content before/afterward) can trigger the warning but nothing will get indexed, multiline_event_extra_waittime, time_before_close and EVENT_BREAKER can resolve this edge case```
 index=_internal sourcetype=splunkd ("Failed to parse timestamp" "Defaulting to timestamp of previous event") OR "Breaking event because limit of " OR "outside of the acceptable time window" (`indexerhosts`) OR (`heavyforwarderhosts`) $sourcetype$
 | bin _time span=1m
 | eval host=data_host, source=data_source, sourcetype=data_sourcetype
 | rex "source::(?P&lt;source&gt;[^|]+)\|host::(?P&lt;host&gt;[^|]+)\|(?P&lt;sourcetype&gt;[^|]+)"
 | eventstats count(eval(isnotnull(data_host))) AS hasBrokenEventOrTuncatedLine, count(eval(searchmatch("outside of the acceptable time window"))) AS outsideTimewindow by _time, host, source, sourcetype
 | where hasBrokenEventOrTuncatedLine=0 AND isnull(data_host) AND NOT searchmatch("outside of the acceptable time window")
-| search ```To investigate further we want the previous timestamp that Splunk used for the event in question, that way we can see what it looks like in raw format...```
+```To investigate further we want the previous timestamp that Splunk used for the event in question, that way we can see what it looks like in raw format...```
 | rex "Defaulting to timestamp of previous event \((?P&lt;previousTimeStamp&gt;[^)]+)"
 | eval previousTimeStamp=strptime(previousTimeStamp, "%a %b %d %H:%M:%S %Y")
 | stats count, min(_time) AS firstSeen, max(_time) AS mostRecent, first(previousTimeStamp) AS recentExample, sum(outsideTimewindow) AS outsideTimewindow by host, sourcetype, source
@@ -40,7 +40,7 @@ index=_internal sourcetype=splunkd ("Failed to parse timestamp" "Defaulting to t
 | eval invesDataSource=if(mvcount(invesDataSource)&gt;1,mvjoin(invesDataSource,"\" OR source=\""),invesDataSource)
 | eval invesDataSource = "source=\"" + invesDataSource + "\""
 | eval invesDataSource = replace(invesDataSource, "\\\\", "\\\\\\\\")
-| eval investigationQuery="```\"The investigation query may find zero data if the data was sent to the null queue by a transforms.conf as the time parsing occurs before the transforms occur. If this source/sourcetype has a null queue you may need to exclude it from this alert\``` ```\"Note that the host= can be inaccurate if host overrides are in use in transforms.conf, if this query finds no results remove host=...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" " . invesDataSource . " earliest=" . recentExample . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"
+| eval investigationQuery="```The investigation query may find zero data if the data was sent to the null queue by a transforms.conf as the time parsing occurs before the transforms occur. If this source/sourcetype has a null queue you may need to exclude it from this alert. Note that the host= can be inaccurate if host overrides are in use in transforms.conf, if this query finds no results remove host=...``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" " . invesDataSource . " earliest=" . recentExample . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"
 | eval mostRecent=strftime(mostRecent, "%+"), firstSeen=strftime(firstSeen, "%+")
 | eval outsideAcceptableTimeWindow=if(outsideTimewindow!=0,"Timestamp parsing failed due to been outside the acceptable time window","No")
 | fields - recentExample, invesEnd, invesDataSource, outsideTimewindow
@@ -73,19 +73,19 @@ OR "is too far away from the previous event's time"
 OR "is suspiciously far away from the previous event's time" $sourcetype$
 | rex "source::(?P&lt;source&gt;[^|]+)\|host::(?P&lt;host&gt;[^|]+)\|(?P&lt;sourcetype&gt;[^|]+)"
 | rex "Context: source=(?P&lt;source&gt;[^|]+)\|host=(?P&lt;host&gt;[^|]+)\|(?P&lt;sourcetype&gt;[^|]+)"
-| search ```The goal of this part of the search was to obtain the messages that are relating to this particular host/source/sourcetype, however since the message includes a time we cannot uses values(message) without getting a huge number of values, therefore we use cluster to obtain the unique values. Since we want the original start/end times we use labelonly=true```
+```The goal of this part of the search was to obtain the messages that are relating to this particular host/source/sourcetype, however since the message includes a time we cannot uses values(message) without getting a huge number of values, therefore we use cluster to obtain the unique values. Since we want the original start/end times we use labelonly=true```
 | cluster labelonly=true
 | eval message=coalesce(message,event_message)
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen, first(message) AS message by host, source, sourcetype, cluster_label
-| search ```While 'A possible timestamp match (...) is outside of the acceptable time window' and 'Time parsed (...) is too far away from the previous event's time', result in the current indexing time been used, the 'Accepted time (...) is suspiciously far away from the previous event's time' is accepted and therefore we need to expand the investigation query time to include this time range as well!```
+```While 'A possible timestamp match (...) is outside of the acceptable time window' and 'Time parsed (...) is too far away from the previous event's time', result in the current indexing time been used, the 'Accepted time (...) is suspiciously far away from the previous event's time' is accepted and therefore we need to expand the investigation query time to include this time range as well!```
 | rex field=message "Accepted time \((?P&lt;acceptedTime&gt;[^\)]+)"
 | eval acceptedTime=strptime(acceptedTime, "%a %b %d %H:%M:%S %Y")
 | eval firstSeen=if(acceptedTime&lt;firstSeen,acceptedTime,firstSeen)
-| search ```Now that we have the first message for each labelled cluster, we now take all relevant message per host/source/sourcetype```
+ ```Now that we have the first message for each labelled cluster, we now take all relevant message per host/source/sourcetype```
 | stats values(acceptedTime) AS acceptedTime, sum(count) AS count, min(firstSeen) AS firstSeen, max(lastSeen) AS lastSeen, values(message) AS message by host, source, sourcetype
 | eval invesEnd=if(lastSeen=firstSeen,round(lastSeen+1),round(lastSeen)), invesStart=floor(firstSeen)
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\")
-| eval investigationQuery="```\"Please note that this query may need to be narrowed down further before running it, this is an example only...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" earliest=" . invesStart . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"
+| eval investigationQuery="```Please note that this query may need to be narrowed down further before running it, this is an example only...``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" earliest=" . invesStart . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"
 | eval firstSeen=strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")
 | table host, source, sourcetype count, firstSeen, lastSeen, message, investigationQuery
 | sort - count</query>
@@ -117,7 +117,7 @@ index=_internal "DateParserVerbose - Accepted time format has changed" sourcetyp
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen by host, source, sourcetype, message
 | eval invesMaxTime=if(firstSeen=lastSeen,lastSeen+1,lastSeen)
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\")
-| eval potentialInvestigationQuery="```\"If no results are found, prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\``` index=* sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" host=" . host . " earliest=" . firstSeen . " latest=" . invesMaxTime . " | eval start=substr(_raw, 0, 30) | cluster field=start"
+| eval potentialInvestigationQuery="```If no results are found, prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...``` index=* sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" host=" . host . " earliest=" . firstSeen . " latest=" . invesMaxTime . " | eval start=substr(_raw, 0, 30) | cluster field=start"
 | eval firstSeen=strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")
 | fields - invesMaxTime, invesDataSource
 | sort - count</query>
@@ -142,15 +142,15 @@ index=_internal "DateParserVerbose - Accepted time format has changed" sourcetyp
       <table>
         <title>The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events...(use a LINE_BREAKER or adjust MAX_EVENTS)</title>
         <search>
-          <query>```The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events...```
-```If running Splunk 7 or newer than refer to the monitoring console Indexing -&gt; Inputs -&gt; Data Quality```
+          <query>```The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events...
+Also refer to the monitoring console Indexing -&gt; Inputs -&gt; Data Quality```
 index=_internal "AggregatorMiningProcessor - Breaking event because limit of" sourcetype=splunkd data_sourcetype=$sourcetype$
 | rex "Breaking event because limit of (?P&lt;curlimit&gt;\d+)"
 | stats max(_time) AS mostRecent, min(_time) AS firstSeen, count by data_sourcetype, data_host, curlimit
 | eval longerThan=curlimit-1
 | eval invesLatest = if(mostRecent==firstSeen,mostRecent+1,mostRecent)
 | rename data_sourcetype AS sourcetype, data_host AS host
-| eval investigationQuery="```\"If no results are found prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" linecount&gt;" . longerThan . " earliest=" . firstSeen . " latest=" . invesLatest
+| eval investigationQuery="```If no results are found prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" linecount&gt;" . longerThan . " earliest=" . firstSeen . " latest=" . invesLatest
 | fields - firstSeen, longerThan, invesLatest
 | eval mostRecent=strftime(mostRecent, "%+")
 | sort - count</query>
@@ -214,7 +214,7 @@ index=_internal "AggregatorMiningProcessor - Breaking event because limit of" so
     where _index_earliest=-7d, earliest=-300d, latest=-7d, sourcetype=$sourcetype$
     groupby source, sourcetype, index, host
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\"), invesLatestTime=mostRecentlySeen+1, invesLatestIndexTime=mostRecentlyIndexed+1
-| eval investigationQuery="```\"Narrow down to the older part of the timeline after this query runs to see the potential issue...\``` index=" . index . " source=\"" . invesDataSource . "\" sourcetype=\"" . sourcetype . "\" host=" . host . " earliest=" . earliestSeen . " latest=" . invesLatestTime . " _index_earliest=" . earliestIndexTime . " _index_latest=" . invesLatestIndexTime . " | eval indextime=strftime(_indextime, \"%+\")"
+| eval investigationQuery="```Narrow down to the older part of the timeline after this query runs to see the potential issue...``` index=" . index . " source=\"" . invesDataSource . "\" sourcetype=\"" . sourcetype . "\" host=" . host . " earliest=" . earliestSeen . " latest=" . invesLatestTime . " _index_earliest=" . earliestIndexTime . " _index_latest=" . invesLatestIndexTime . " | eval indextime=strftime(_indextime, \"%+\")"
 | eval mostRecentlySeen=strftime(mostRecentlySeen, "%+"), mostRecentlyIndexed=strftime(mostRecentlyIndexed, "%+")
 | sort index, host, sourcetype
 | table index, source, sourcetype, host, mostRecentlySeen, mostRecentlyIndexed, count, investigationQuery</query>
@@ -238,9 +238,9 @@ index=_internal "AggregatorMiningProcessor - Breaking event because limit of" so
       <table>
         <title>The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)</title>
         <search>
-          <query>```The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)```
-```If running Splunk 7 or newer than refer to the Monitoring Console, Indexing -&gt; Inputs -&gt; Data Quality```
-```If you are in a (very) performance sensitive environment you might want to remove the rex/eval lines for the data_host field and let the admin update the inves query manually```
+          <query>```The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)
+Also refer to the Monitoring Console, Indexing -&gt; Inputs -&gt; Data Quality
+If you are in a (very) performance sensitive environment you might want to remove the rex/eval lines for the data_host field and let the admin update the investigation query manually```
 index=_internal "Truncating line because limit of" sourcetype=splunkd data_sourcetype=$sourcetype$ (`heavyforwarderhosts`) OR (`indexerhosts`)
 | rex "Truncating line because limit of (?P&lt;curlimit&gt;\d+) bytes.*with a line length &gt;= (?P&lt;approxlinelength&gt;\S+)"
 | rex field=data_host "(?P&lt;data_host&gt;[^\.]+)"
@@ -253,7 +253,7 @@ index=_internal "Truncating line because limit of" sourcetype=splunkd data_sourc
 | eval invesLastSeen=if(firstSeen==lastSeen,lastSeen+1,lastSeen)
 | eval firstSeen=firstSeen-10
 | eval invesLastSeen=invesLastSeen+10
-| eval investigationQuery="```\"Find examples where the truncation limit has been reached\``` ```\"The earliest/latest time is based on the warning messages in the Splunk logs, they may need customisation!\``` index=* sourcetype=" . sourcetype . " " . hostList . " earliest=" . firstSeen . " latest=" . invesLastSeen . " | where len(_raw)=" . curlimit
+| eval investigationQuery="```Find examples where the truncation limit has been reached. The earliest/latest time is based on the warning messages in the Splunk logs, they may need customisation!``` index=* sourcetype=" . sourcetype . " " . hostList . " earliest=" . firstSeen . " latest=" . invesLastSeen . " | where len(_raw)=" . curlimit
 | sort - count
 | eval lastSeen=strftime(lastSeen, "%+")
 | table sourcetype, curlimit, count, avgApproxLineLength, maxApproxLineLength, lastSeen, investigationQuery

--- a/default/data/ui/views/issues_per_sourcetype.xml
+++ b/default/data/ui/views/issues_per_sourcetype.xml
@@ -19,17 +19,17 @@
       <table>
         <title>Timestamp parsing has failed, note that if the null queue is in use this can give false alarms</title>
         <search>
-          <query>`comment("Timestamp parsing has failed, and it doesn't appear to be related to the event been broken due to having too many lines, that is a separate alert that may trigger a timestamp parsing issue (excluded from this alert as that issue needs to be resolved first)")`
-`comment("Please note that you may see this particular warning on data that is sent to the nullQueue using a transforms.conf. Obviously you won't see this in the index but you will see the warning because the time parsing occurs before the transforms.conf occurs")`
-`comment("This alert now checks for at least 2 failures, and header entries can often trigger 2 entries in the log files about timestamp parsing failures...")`
-`comment("Finally one strange edge case is a newline inserted into the log file (by itself with no content before/afterward) can trigger the warning but nothing will get indexed, multiline_event_extra_waittime, time_before_close and EVENT_BREAKER can resolve this edge case")`
+          <query>```Timestamp parsing has failed, and it doesn't appear to be related to the event been broken due to having too many lines, that is a separate alert that may trigger a timestamp parsing issue (excluded from this alert as that issue needs to be resolved first)```
+```Please note that you may see this particular warning on data that is sent to the nullQueue using a transforms.conf. Obviously you won't see this in the index but you will see the warning because the time parsing occurs before the transforms.conf occurs```
+```This alert now checks for at least 2 failures, and header entries can often trigger 2 entries in the log files about timestamp parsing failures...```
+```Finally one strange edge case is a newline inserted into the log file (by itself with no content before/afterward) can trigger the warning but nothing will get indexed, multiline_event_extra_waittime, time_before_close and EVENT_BREAKER can resolve this edge case```
 index=_internal sourcetype=splunkd ("Failed to parse timestamp" "Defaulting to timestamp of previous event") OR "Breaking event because limit of " OR "outside of the acceptable time window" (`indexerhosts`) OR (`heavyforwarderhosts`) $sourcetype$
 | bin _time span=1m
 | eval host=data_host, source=data_source, sourcetype=data_sourcetype
 | rex "source::(?P&lt;source&gt;[^|]+)\|host::(?P&lt;host&gt;[^|]+)\|(?P&lt;sourcetype&gt;[^|]+)"
 | eventstats count(eval(isnotnull(data_host))) AS hasBrokenEventOrTuncatedLine, count(eval(searchmatch("outside of the acceptable time window"))) AS outsideTimewindow by _time, host, source, sourcetype
 | where hasBrokenEventOrTuncatedLine=0 AND isnull(data_host) AND NOT searchmatch("outside of the acceptable time window")
-| search `comment("To investigate further we want the previous timestamp that Splunk used for the event in question, that way we can see what it looks like in raw format...")`
+| search ```To investigate further we want the previous timestamp that Splunk used for the event in question, that way we can see what it looks like in raw format...```
 | rex "Defaulting to timestamp of previous event \((?P&lt;previousTimeStamp&gt;[^)]+)"
 | eval previousTimeStamp=strptime(previousTimeStamp, "%a %b %d %H:%M:%S %Y")
 | stats count, min(_time) AS firstSeen, max(_time) AS mostRecent, first(previousTimeStamp) AS recentExample, sum(outsideTimewindow) AS outsideTimewindow by host, sourcetype, source
@@ -40,7 +40,7 @@ index=_internal sourcetype=splunkd ("Failed to parse timestamp" "Defaulting to t
 | eval invesDataSource=if(mvcount(invesDataSource)&gt;1,mvjoin(invesDataSource,"\" OR source=\""),invesDataSource)
 | eval invesDataSource = "source=\"" + invesDataSource + "\""
 | eval invesDataSource = replace(invesDataSource, "\\\\", "\\\\\\\\")
-| eval investigationQuery="`comment(\"The investigation query may find zero data if the data was sent to the null queue by a transforms.conf as the time parsing occurs before the transforms occur. If this source/sourcetype has a null queue you may need to exclude it from this alert\")` `comment(\"Note that the host= can be inaccurate if host overrides are in use in transforms.conf, if this query finds no results remove host=...\")` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" " . invesDataSource . " earliest=" . recentExample . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"
+| eval investigationQuery="```\"The investigation query may find zero data if the data was sent to the null queue by a transforms.conf as the time parsing occurs before the transforms occur. If this source/sourcetype has a null queue you may need to exclude it from this alert\``` ```\"Note that the host= can be inaccurate if host overrides are in use in transforms.conf, if this query finds no results remove host=...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" " . invesDataSource . " earliest=" . recentExample . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"
 | eval mostRecent=strftime(mostRecent, "%+"), firstSeen=strftime(firstSeen, "%+")
 | eval outsideAcceptableTimeWindow=if(outsideTimewindow!=0,"Timestamp parsing failed due to been outside the acceptable time window","No")
 | fields - recentExample, invesEnd, invesDataSource, outsideTimewindow
@@ -66,26 +66,26 @@ index=_internal sourcetype=splunkd ("Failed to parse timestamp" "Defaulting to t
       <table>
         <title>The timestamp parsing did run but the timestamp found did not match previous events so the time parsing may need a review</title>
         <search>
-          <query>`comment("The timestamp parsing did run but the timestamp found did not match previous events so the time parsing may need a review")`
+          <query>```The timestamp parsing did run but the timestamp found did not match previous events so the time parsing may need a review```
 index=_internal sourcetype=splunkd (`indexerhosts`) OR (`heavyforwarderhosts`)
 "outside of the acceptable time window. If this timestamp is correct, consider adjusting"
 OR "is too far away from the previous event's time"
 OR "is suspiciously far away from the previous event's time" $sourcetype$
 | rex "source::(?P&lt;source&gt;[^|]+)\|host::(?P&lt;host&gt;[^|]+)\|(?P&lt;sourcetype&gt;[^|]+)"
 | rex "Context: source=(?P&lt;source&gt;[^|]+)\|host=(?P&lt;host&gt;[^|]+)\|(?P&lt;sourcetype&gt;[^|]+)"
-| search `comment("The goal of this part of the search was to obtain the messages that are relating to this particular host/source/sourcetype, however since the message includes a time we cannot uses values(message) without getting a huge number of values, therefore we use cluster to obtain the unique values. Since we want the original start/end times we use labelonly=true")`
+| search ```The goal of this part of the search was to obtain the messages that are relating to this particular host/source/sourcetype, however since the message includes a time we cannot uses values(message) without getting a huge number of values, therefore we use cluster to obtain the unique values. Since we want the original start/end times we use labelonly=true```
 | cluster labelonly=true
 | eval message=coalesce(message,event_message)
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen, first(message) AS message by host, source, sourcetype, cluster_label
-| search `comment("While 'A possible timestamp match (...) is outside of the acceptable time window' and 'Time parsed (...) is too far away from the previous event's time', result in the current indexing time been used, the 'Accepted time (...) is suspiciously far away from the previous event's time' is accepted and therefore we need to expand the investigation query time to include this time range as well!")`
+| search ```While 'A possible timestamp match (...) is outside of the acceptable time window' and 'Time parsed (...) is too far away from the previous event's time', result in the current indexing time been used, the 'Accepted time (...) is suspiciously far away from the previous event's time' is accepted and therefore we need to expand the investigation query time to include this time range as well!```
 | rex field=message "Accepted time \((?P&lt;acceptedTime&gt;[^\)]+)"
 | eval acceptedTime=strptime(acceptedTime, "%a %b %d %H:%M:%S %Y")
 | eval firstSeen=if(acceptedTime&lt;firstSeen,acceptedTime,firstSeen)
-| search `comment("Now that we have the first message for each labelled cluster, we now take all relevant message per host/source/sourcetype")`
+| search ```Now that we have the first message for each labelled cluster, we now take all relevant message per host/source/sourcetype```
 | stats values(acceptedTime) AS acceptedTime, sum(count) AS count, min(firstSeen) AS firstSeen, max(lastSeen) AS lastSeen, values(message) AS message by host, source, sourcetype
 | eval invesEnd=if(lastSeen=firstSeen,round(lastSeen+1),round(lastSeen)), invesStart=floor(firstSeen)
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\")
-| eval investigationQuery="`comment(\"Please note that this query may need to be narrowed down further before running it, this is an example only...\")` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" earliest=" . invesStart . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"
+| eval investigationQuery="```\"Please note that this query may need to be narrowed down further before running it, this is an example only...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" earliest=" . invesStart . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"
 | eval firstSeen=strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")
 | table host, source, sourcetype count, firstSeen, lastSeen, message, investigationQuery
 | sort - count</query>
@@ -110,14 +110,14 @@ OR "is suspiciously far away from the previous event's time" $sourcetype$
       <table>
         <title>Normally this alert advises that a sourcetype is been used by multiple unique types of data (i.e. it should be more than one sourcetype), one way to fix this is at the universal forwarder / inputs.conf sourcetype= setting</title>
         <search>
-          <query>`comment("This search detects when the time format has changed within the files 1 or more times, the time format per sourcetype should be consistent")`
+          <query>```This search detects when the time format has changed within the files 1 or more times, the time format per sourcetype should be consistent```
 index=_internal "DateParserVerbose - Accepted time format has changed" sourcetype=splunkd (`indexerhosts`) OR (`heavyforwarderhosts`) $sourcetype$
 | rex "source(?:=|::)(?P&lt;source&gt;[^|]+)\|host(?:=|::)(?P&lt;host&gt;[^|]+)\|(?P&lt;sourcetype&gt;[^|]+)"
 | eval message=coalesce(message,event_message)
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen by host, source, sourcetype, message
 | eval invesMaxTime=if(firstSeen=lastSeen,lastSeen+1,lastSeen)
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\")
-| eval potentialInvestigationQuery="`comment(\"If no results are found, prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\")` index=* sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" host=" . host . " earliest=" . firstSeen . " latest=" . invesMaxTime . " | eval start=substr(_raw, 0, 30) | cluster field=start"
+| eval potentialInvestigationQuery="```\"If no results are found, prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\``` index=* sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" host=" . host . " earliest=" . firstSeen . " latest=" . invesMaxTime . " | eval start=substr(_raw, 0, 30) | cluster field=start"
 | eval firstSeen=strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")
 | fields - invesMaxTime, invesDataSource
 | sort - count</query>
@@ -142,15 +142,15 @@ index=_internal "DateParserVerbose - Accepted time format has changed" sourcetyp
       <table>
         <title>The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events...(use a LINE_BREAKER or adjust MAX_EVENTS)</title>
         <search>
-          <query>`comment("The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events...")`
-`comment("If running Splunk 7 or newer than refer to the monitoring console Indexing -&gt; Inputs -&gt; Data Quality")`
+          <query>```The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events...```
+```If running Splunk 7 or newer than refer to the monitoring console Indexing -&gt; Inputs -&gt; Data Quality```
 index=_internal "AggregatorMiningProcessor - Breaking event because limit of" sourcetype=splunkd data_sourcetype=$sourcetype$
 | rex "Breaking event because limit of (?P&lt;curlimit&gt;\d+)"
 | stats max(_time) AS mostRecent, min(_time) AS firstSeen, count by data_sourcetype, data_host, curlimit
 | eval longerThan=curlimit-1
 | eval invesLatest = if(mostRecent==firstSeen,mostRecent+1,mostRecent)
 | rename data_sourcetype AS sourcetype, data_host AS host
-| eval investigationQuery="`comment(\"If no results are found prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\")` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" linecount&gt;" . longerThan . " earliest=" . firstSeen . " latest=" . invesLatest
+| eval investigationQuery="```\"If no results are found prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" linecount&gt;" . longerThan . " earliest=" . firstSeen . " latest=" . invesLatest
 | fields - firstSeen, longerThan, invesLatest
 | eval mostRecent=strftime(mostRecent, "%+")
 | sort - count</query>
@@ -214,7 +214,7 @@ index=_internal "AggregatorMiningProcessor - Breaking event because limit of" so
     where _index_earliest=-7d, earliest=-300d, latest=-7d, sourcetype=$sourcetype$
     groupby source, sourcetype, index, host
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\"), invesLatestTime=mostRecentlySeen+1, invesLatestIndexTime=mostRecentlyIndexed+1
-| eval investigationQuery="`comment(\"Narrow down to the older part of the timeline after this query runs to see the potential issue...\")` index=" . index . " source=\"" . invesDataSource . "\" sourcetype=\"" . sourcetype . "\" host=" . host . " earliest=" . earliestSeen . " latest=" . invesLatestTime . " _index_earliest=" . earliestIndexTime . " _index_latest=" . invesLatestIndexTime . " | eval indextime=strftime(_indextime, \"%+\")"
+| eval investigationQuery="```\"Narrow down to the older part of the timeline after this query runs to see the potential issue...\``` index=" . index . " source=\"" . invesDataSource . "\" sourcetype=\"" . sourcetype . "\" host=" . host . " earliest=" . earliestSeen . " latest=" . invesLatestTime . " _index_earliest=" . earliestIndexTime . " _index_latest=" . invesLatestIndexTime . " | eval indextime=strftime(_indextime, \"%+\")"
 | eval mostRecentlySeen=strftime(mostRecentlySeen, "%+"), mostRecentlyIndexed=strftime(mostRecentlyIndexed, "%+")
 | sort index, host, sourcetype
 | table index, source, sourcetype, host, mostRecentlySeen, mostRecentlyIndexed, count, investigationQuery</query>
@@ -238,9 +238,9 @@ index=_internal "AggregatorMiningProcessor - Breaking event because limit of" so
       <table>
         <title>The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)</title>
         <search>
-          <query>`comment("The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)")`
-`comment("If running Splunk 7 or newer than refer to the Monitoring Console, Indexing -&gt; Inputs -&gt; Data Quality")`
-`comment("If you are in a (very) performance sensitive environment you might want to remove the rex/eval lines for the data_host field and let the admin update the inves query manually")`
+          <query>```The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)```
+```If running Splunk 7 or newer than refer to the Monitoring Console, Indexing -&gt; Inputs -&gt; Data Quality```
+```If you are in a (very) performance sensitive environment you might want to remove the rex/eval lines for the data_host field and let the admin update the inves query manually```
 index=_internal "Truncating line because limit of" sourcetype=splunkd data_sourcetype=$sourcetype$ (`heavyforwarderhosts`) OR (`indexerhosts`)
 | rex "Truncating line because limit of (?P&lt;curlimit&gt;\d+) bytes.*with a line length &gt;= (?P&lt;approxlinelength&gt;\S+)"
 | rex field=data_host "(?P&lt;data_host&gt;[^\.]+)"
@@ -253,7 +253,7 @@ index=_internal "Truncating line because limit of" sourcetype=splunkd data_sourc
 | eval invesLastSeen=if(firstSeen==lastSeen,lastSeen+1,lastSeen)
 | eval firstSeen=firstSeen-10
 | eval invesLastSeen=invesLastSeen+10
-| eval investigationQuery="`comment(\"Find examples where the truncation limit has been reached\")` `comment(\"The earliest/latest time is based on the warning messages in the Splunk logs, they may need customisation!\")` index=* sourcetype=" . sourcetype . " " . hostList . " earliest=" . firstSeen . " latest=" . invesLastSeen . " | where len(_raw)=" . curlimit
+| eval investigationQuery="```\"Find examples where the truncation limit has been reached\``` ```\"The earliest/latest time is based on the warning messages in the Splunk logs, they may need customisation!\``` index=* sourcetype=" . sourcetype . " " . hostList . " earliest=" . firstSeen . " latest=" . invesLastSeen . " | where len(_raw)=" . curlimit
 | sort - count
 | eval lastSeen=strftime(lastSeen, "%+")
 | table sourcetype, curlimit, count, avgApproxLineLength, maxApproxLineLength, lastSeen, investigationQuery

--- a/default/data/ui/views/knowledge_objects_by_app.xml
+++ b/default/data/ui/views/knowledge_objects_by_app.xml
@@ -26,7 +26,7 @@
         <query>| rest "/servicesNS/-/$app$/directory" count=0 splunk_server=local
 | search eai:acl.app=$app$
 | rename eai:type AS type
-| search type!="macros" `comment("macros only appears in really new versions of Splunk via the directory endpoint, so assume it doesn't exist in this query")`
+| search type!="macros" ```macros only appears in really new versions of Splunk via the directory endpoint, so assume it doesn't exist in this query```
 | stats count by type
 | fields - count</query>
         <earliest>-24h@h</earliest>

--- a/default/data/ui/views/smartstore_stats.xml
+++ b/default/data/ui/views/smartstore_stats.xml
@@ -101,7 +101,7 @@
       <title>CacheManager Queued download count</title>
       <chart>
         <search>
-          <query>`comment("Relates to [cachemanager] max_concurrent_downloads in server.conf. Thanks to Splunk support for the original version of this search")` index=_internal $host$ `splunkadmins_metrics_source` TERM(group=cachemgr_download) sourcetype=splunkd queued 
+          <query>```Relates to [cachemanager] max_concurrent_downloads in server.conf. Thanks to Splunk support for the original version of this search``` index=_internal $host$ `splunkadmins_metrics_source` TERM(group=cachemgr_download) sourcetype=splunkd queued 
 | timechart partial=f limit=50 avg(queued) AS avg_queued by host 
 | eval ceiling=20</query>
           <earliest>$time.earliest$</earliest>
@@ -136,7 +136,7 @@
       <title>Excessive cachemanager downloads</title>
       <chart>
         <search>
-          <query>`comment("Thanks to Splunk support for the original version of this search, similar version available in the monitoring console...")` index=_internal $host$ `splunkadmins_splunkd_source` sourcetype=splunkd CacheManager TERM(action=download) TERM(status=succeeded) TERM(download_set=*)
+          <query>```Thanks to Splunk support for the original version of this search, similar version available in the monitoring console...``` index=_internal $host$ `splunkadmins_splunkd_source` sourcetype=splunkd CacheManager TERM(action=download) TERM(status=succeeded) TERM(download_set=*)
 | rex field=cache_id "&gt;*\|(?&lt;index_name&gt;.*)~.*~.*\|" 
 | eval identifier=(cache_id + host) 
 | stats count by identifier, index_name 
@@ -159,7 +159,7 @@
       <title>CacheManager downloads by age/index</title>
       <chart>
         <search>
-          <query>`comment("Thanks to Splunk support for the original version of this search")` index=_audit $host$ TERM(action=remote_bucket_download) TERM(info=completed)
+          <query>```Thanks to Splunk support for the original version of this search``` index=_audit $host$ TERM(action=remote_bucket_download) TERM(info=completed)
 | eval gbps=kb/1024/1024 
 | eval age=round((now()-earliest_time)/60/60/24) 
 | bucket span=30 age 

--- a/default/data/ui/views/splunk_forwarder_output_tuning.xml
+++ b/default/data/ui/views/splunk_forwarder_output_tuning.xml
@@ -80,7 +80,7 @@
       <title>Data output std deviation</title>
       <chart>
         <search>
-          <query>`comment("Credit to Brett Adams")` index=_internal $host$ sourcetype=splunkd `splunkadmins_metrics_source` component=Metrics TERM(group=tcpout_connections) name=$output_group$*
+          <query>```Credit to Brett Adams``` index=_internal $host$ sourcetype=splunkd `splunkadmins_metrics_source` component=Metrics TERM(group=tcpout_connections) name=$output_group$*
 | rex field=name "(?P&lt;destination&gt;[^:]+)"
 | search destination=$output_group$*
 | timechart span=1m sum(kb) by destIp limit=50

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -97,7 +97,7 @@ iseval = 0
 #simplifying this in the past has resulted in missing at least 1 type of shutdown or the start of the shutdown process...
 [splunkadmins_shutdown_list(3)]
 args = macroName, minTimeContingency, maxTimeContingency
-definition = search `comment("Send an exclusion list in terms of a search result for when this particular Splunk server was shutdown, plus any contingency time as requested")`\
+definition = search ```Send an exclusion list in terms of a search result for when this particular Splunk server was shutdown, plus any contingency time as requested```\
 index=_internal (`$macroName$`) sourcetype=splunkd `splunkadmins_splunkd_source` (CASE("Shutting down")) OR "Shutdown complete in" OR "Received shutdown signal." OR "master has instructed peer to restart" OR "Performing early shutdown tasks"\
 | eval message=coalesce(message,event_message)\
 | stats min(_time) AS logTime by message, host\
@@ -120,7 +120,7 @@ iseval = 0
 #simplifying this in the past has resulted in missing at least 1 type of shutdown or the start of the shutdown process...
 [splunkadmins_shutdown_keyword(3)]
 args = macroName, minTimeContingency, maxTimeContingency
-definition = search `comment("Send an exclusion list in terms of a search result for when this particular Splunk server was shutdown, plus any contingency time as requested")`\
+definition = search ```Send an exclusion list in terms of a search result for when this particular Splunk server was shutdown, plus any contingency time as requested```\
 index=_internal (`$macroName$`) sourcetype=splunkd `splunkadmins_splunkd_source` (CASE("Shutting down")) OR "Shutdown complete in" OR "Received shutdown signal." OR "master has instructed peer to restart" OR "Performing early shutdown tasks"\
 | eval message=coalesce(message,event_message)\
 | stats min(_time) AS logTime by message, host\
@@ -143,7 +143,7 @@ iseval = 0
 #simplifying this in the past has resulted in missing at least 1 type of shutdown or the start of the shutdown process...
 [splunkadmins_shutdown_time(3)]
 args = macroName, minTimeContingency, maxTimeContingency
-definition = search `comment("Send an exclusion list in terms of a search result for the time when any indexer was shutdown")`\
+definition = search ```Send an exclusion list in terms of a search result for the time when any indexer was shutdown```\
 index=_internal (`$macroName$`) sourcetype=splunkd `splunkadmins_splunkd_source` (CASE("Shutting down")) OR "Shutdown complete in" OR "Received shutdown signal." OR "master has instructed peer to restart" OR "Performing early shutdown tasks"\
 | eval message=coalesce(message,event_message)\
 | stats min(_time) AS logTime by message, host\
@@ -158,7 +158,7 @@ iseval = 0
 # variation of the above to utilise smaller blocks of time during the search
 [splunkadmins_shutdown_time_by_period(4)]
 args = macroName, minTimeContingency, maxTimeContingency, period
-definition = search `comment("Send an exclusion list in terms of a search result for the time when any indexer was shutdown")`\
+definition = search ```Send an exclusion list in terms of a search result for the time when any indexer was shutdown```\
 index=_internal (`$macroName$`) sourcetype=splunkd `splunkadmins_splunkd_source` (CASE("Shutting down")) OR "Shutdown complete in" OR "Received shutdown signal." OR "master has instructed peer to restart" OR "Performing early shutdown tasks"\
 | eval message=coalesce(message,event_message)\
 | bin _time span=$period$\
@@ -200,7 +200,7 @@ definition = 3
 iseval = 0
 
 [splunkadmins_btoolvalidation_ds]
-definition = `comment("Splunk for stream doesn't include a config file which causes errors, however it appears to work without it...")` NOT "/opt/splunk/etc/deployment-apps/Splunk_TA_stream*"
+definition = ```Splunk for stream doesn't include a config file which causes errors, however it appears to work without it...``` NOT "/opt/splunk/etc/deployment-apps/Splunk_TA_stream*"
 iseval = 0
 
 [splunkadmins_bandwidth]
@@ -309,7 +309,7 @@ definition = ""
 iseval = 0
 
 [splunkadmins_longrunning_searches]
-definition = `comment("Exclude various standard/expected searches")` savedsearch_name!="Generate Meta Woot! every 15 mins" savedsearch_name!="Generate NMON*"
+definition = ```Exclude various standard/expected searches``` savedsearch_name!="Generate Meta Woot! every 15 mins" savedsearch_name!="Generate NMON*"
 iseval = 0
 
 [splunkadmins_realtime_scheduledsearches]
@@ -400,7 +400,7 @@ iseval = 0
 
 #Ignore enterprise security related sendalert errors, they are often false alarms here, also filter the data a bit further...
 [splunkadmins_sendmodalert_errors]
-definition = `comment("We look for the sendalert commands to provide context around the errors where possible. Since notable/risks fail more often they are removed from this particular alert")` NOT action=notable NOT action=risk NOT (" - INFO]" OR "Results Link" OR "Alert Name:")
+definition = ```We look for the sendalert commands to provide context around the errors where possible. Since notable/risks fail more often they are removed from this particular alert``` NOT action=notable NOT action=risk NOT (" - INFO]" OR "Results Link" OR "Alert Name:")
 iseval = 0
 
 [splunkadmins_bucketrolling_count]
@@ -453,12 +453,12 @@ iseval = 0
 
 #Ignore internal indexes introspection & main
 [splunkadmins_colddata]
-definition = `comment("Some internal indexes roll based on size by default such as introspection")` index!=_introspection index!=defaultdb
+definition = ```Some internal indexes roll based on size by default such as introspection``` index!=_introspection index!=defaultdb
 iseval = 0
 
 #Ignore internal indexes introspection & main
 [splunkadmins_bucketfrozen]
-definition = `comment("Some internal indexes roll based on size by default such as introspection")` bkt!="*_introspection*" bkt!="*defaultdb*"
+definition = ```Some internal indexes roll based on size by default such as introspection``` bkt!="*_introspection*" bkt!="*defaultdb*"
 iseval = 0
 
 [splunkadmins_permissions]
@@ -467,7 +467,7 @@ iseval = 0
 
 #Ignore internal indexes introspection & main
 [splunkadmins_warmdbcount]
-definition = `comment("We probably don't care about the warm limits for the internal indexes...")` index!=_introspection index!=defaultdb
+definition = ```We probably don't care about the warm limits for the internal indexes...``` index!=_introspection index!=defaultdb
 iseval = 0
 
 [splunkadmins_warmdbcount_perc]
@@ -520,7 +520,7 @@ iseval = 0
 #This macro returns in the form of (_time>start _time<end) this allows entire indexer cluster restarts to be filtered out.
 [splunkadmins_transfer_captain_times(3)]
 args = macroName, minTimeContingency, maxTimeContingency
-definition = search `comment("Send an exclusion list in terms of a search result for the time when a search head captain transfer occurred")` index=_internal (`$macroName$`) sourcetype=splunkd `splunkadmins_splunkd_source` "Got Transfer captaincy" | eval message=coalesce(message,event_message) | stats min(_time) AS logTime by message, host | stats min(logTime) AS minTime, max(logTime) AS maxTime | eval minTime=minTime - $minTimeContingency$, maxTime=maxTime + $maxTimeContingency$ | eval search=" _time>" . minTime . " _time<" .maxTime | fields search | format | rex mode=sed field=search "s/\"//g"
+definition = search ```Send an exclusion list in terms of a search result for the time when a search head captain transfer occurred``` index=_internal (`$macroName$`) sourcetype=splunkd `splunkadmins_splunkd_source` "Got Transfer captaincy" | eval message=coalesce(message,event_message) | stats min(_time) AS logTime by message, host | stats min(logTime) AS minTime, max(logTime) AS maxTime | eval minTime=minTime - $minTimeContingency$, maxTime=maxTime + $maxTimeContingency$ | eval search=" _time>" . minTime . " _time<" .maxTime | fields search | format | rex mode=sed field=search "s/\"//g"
 iseval = 0
 
 [splunkadmins_replicationfactor]
@@ -529,7 +529,7 @@ iseval = 0
 
 [whataccessdoihave]
 definition = rest /services/authentication/users splunk_server=local\
-| search `comment("REST query is limited to the current search head this is running on so we see the index access from this instances point of view")`\
+| search ```REST query is limited to the current search head this is running on so we see the index access from this instances point of view```\
     [| rest /services/authentication/current-context/context splunk_server=local\
     | head 1 \
     | fields username \
@@ -572,14 +572,14 @@ iseval = 0
 #Substitute `<macro name>` within the audit.log files with the audit definition based on a lookup file
 #note this version only substitutes the first macro seen...the Splunk 8 version can handle multiple macros at once
 [splunkadmins_audit_logs_macro_sub]
-definition = search `comment("Set all values to null() in case this macro is called again within the same search. Subsitute a macro used inside a search with the definition found in the lookup file")`\
+definition = search ```Set all values to null() in case this macro is called again within the same search. Subsitute a macro used inside a search with the definition found in the lookup file```\
 | eval definition=null(), commas=null(), commas2=null(), argCount2=null(), argCount=null(), match=null()\
 | rex field=search max_match=1 "\`(?!\")(?!')(?P<macro>[^\`]+)\`" \
-| search `comment("You can have multiple macro definitions with either 0 or more arguments so we have to count them...")` \
+| search ```You can have multiple macro definitions with either 0 or more arguments so we have to count them...``` \
 | rex max_match=10 field=macro "([^\"]+\")|([^']+')\s*(?P<commas>,)" \
 | rex max_match=10 field=macro "(?P<commas2>,)" \
 | rex max_match=1 field=macro "(?P<match>[^\(]+\()" \
-| search `comment("Two count methods are used as if we have macro(arg1) that has no commas, but macro(arg1,arg2) will work as expected...")` \
+| search ```Two count methods are used as if we have macro(arg1) that has no commas, but macro(arg1,arg2) will work as expected...``` \
 | eval argCount2=if(match(macro,"([^\"]+\")|([^']+')") AND isnull(commas),-1,if(isnotnull(commas2),mvcount(commas2),null())) \
 | eval argCount=if(isnull(argCount2),0,argCount2+1) \
 | eval argCount=if(argCount==0,if(isnotnull(match),1,0),argCount) \
@@ -595,54 +595,54 @@ iseval = 0
 #Substitute `<macro name>` within the audit.log files with the audit definition based on a lookup file
 #note this version only works on Splunk 8 due to the use of mvmap
 [splunkadmins_audit_logs_macro_sub_v8]
-definition = search `comment("Set all values to null() in case this macro is called again within the same search. Subsitute a macro used inside a search with the definition found in the lookup file")` \
+definition = search ```Set all values to null() in case this macro is called again within the same search. Subsitute a macro used inside a search with the definition found in the lookup file``` \
 | eval definition=null(), definition2=null(), definition3=null(), commas=null(), commas2=null(), argCount2=null(), argCount=null(), match=null() \
 | rex field=search "\\`(?!\")(?!')(?P<macro>[^\\`]+)\\`" max_match=20 \
-| search `comment("remove any commas inside double quotes or single quotes inside a macro, they are probably not arguments to the macro itself")` \
+| search ```remove any commas inside double quotes or single quotes inside a macro, they are probably not arguments to the macro itself``` \
 | eval remove_commas_inside_macros=mvmap(macro,replace(macro,"(\"[^\"]+\"|'[^']+')","")) \
-| search `comment("Originally a regex, the replace+len works in mvmap and determines number of commas so we can find a macro name")` \
+| search ```Originally a regex, the replace+len works in mvmap and determines number of commas so we can find a macro name``` \
 | eval commas2=mvmap(remove_commas_inside_macros,if(match(remove_commas_inside_macros,"^[^\(]+$"),"-1",len(replace(remove_commas_inside_macros,"[^,]+",""))+1)) \
 | rex field=macro "(?P<macro_name>^[^\( ]+)" max_match=20 \
 | eval macro_commas=mvzip(macro_name,commas2,"!!!!!!!") \
-| search `comment("A macro with zero arguments is -1 from the previous mvmap, if it has non-zero arguments the definition changes to macro(number)...")` \
+| search ```A macro with zero arguments is -1 from the previous mvmap, if it has non-zero arguments the definition changes to macro(number)...``` \
 | eval macroName=mvmap(macro_commas,if(mvindex(split(macro_commas,"!!!!!!!"),1)=="-1",mvindex(split(macro_commas,"!!!!!!!"),0),mvindex(split(macro_commas,"!!!!!!!"),0) . "(" . mvindex(split(macro_commas,"!!!!!!!"),1) . ")")) \
 | lookup splunkadmins_macros title AS macroName, app AS app_name, splunk_server \
 | eval app_name2="global" \
-| search `comment("The original version just did an OUTPUTNEW definition, however this has the limitation that if 1 of the 5 macros found resolves, output stops. And this can result in missing macros. So this version over-matches but that appears to be the tradeoff...without making this even more complicated")` \
+| search ```The original version just did an OUTPUTNEW definition, however this has the limitation that if 1 of the 5 macros found resolves, output stops. And this can result in missing macros. So this version over-matches but that appears to be the tradeoff...without making this even more complicated``` \
 | lookup splunkadmins_macros title AS macroName, app AS app_name2, splunk_server OUTPUT definition AS definition2 \
 | lookup splunkadmins_macros title AS macroName, splunk_server OUTPUT definition AS definition3 \
 | eval definition=mvdedup(mvappend(definition,definition2,definition3)) \
 | fillnull definition value="macronotfound" \
 | nomv definition \
 | eval definition=" " . definition . " " \
-| search `comment("While an mvmap could replace per-macro that results in a multivalue output. Also replace doesn't handle a multivalued replacement argument so just replace the first macro if it exists with the definitions of all the macros, close enough for what we want")` \
+| search ```While an mvmap could replace per-macro that results in a multivalue output. Also replace doesn't handle a multivalued replacement argument so just replace the first macro if it exists with the definitions of all the macros, close enough for what we want``` \
 | eval search=if(isnotnull(macro_name),replace(search,mvindex(macro_name,0),definition),search)
 iseval = 0
 
 #Substitute `<macro name>` within the any file
 [splunkadmins_macro_sub(1)]
 args = fieldname
-definition = search `comment("Set all values to null() in case this macro is called again within the same search. Subsitute a macro used inside a search with the definition found in the lookup file")` \
+definition = search ```Set all values to null() in case this macro is called again within the same search. Subsitute a macro used inside a search with the definition found in the lookup file``` \
 | eval definition=null(), definition2=null(), definition3=null(), commas=null(), commas2=null(), argCount2=null(), argCount=null(), match=null() \
 | rex field=$fieldname$ "\\`(?!\")(?!')(?P<macro>[^\\`]+)\\`" max_match=20 \
-| search `comment("remove any commas inside double quotes or single quotes inside a macro, they are probably not arguments to the macro itself")` \
+| search ```remove any commas inside double quotes or single quotes inside a macro, they are probably not arguments to the macro itself``` \
 | eval remove_commas_inside_macros=mvmap(macro,replace(macro,"(\"[^\"]+\"|'[^']+')","")) \
-| search `comment("Originally a regex, the replace+len works in mvmap and determines number of commas so we can find a macro name")` \
+| search ```Originally a regex, the replace+len works in mvmap and determines number of commas so we can find a macro name``` \
 | eval commas2=mvmap(remove_commas_inside_macros,if(match(remove_commas_inside_macros,"^[^\(]+$"),"-1",len(replace(remove_commas_inside_macros,"[^,]+",""))+1)) \
 | rex field=macro "(?P<macro_name>^[^\( ]+)" max_match=20 \
 | eval macro_commas=mvzip(macro_name,commas2,"!!!!!!!") \
-| search `comment("A macro with zero arguments is -1 from the previous mvmap, if it has non-zero arguments the definition changes to macro(number)...")` \
+| search ```A macro with zero arguments is -1 from the previous mvmap, if it has non-zero arguments the definition changes to macro(number)...``` \
 | eval macroName=mvmap(macro_commas,if(mvindex(split(macro_commas,"!!!!!!!"),1)=="-1",mvindex(split(macro_commas,"!!!!!!!"),0),mvindex(split(macro_commas,"!!!!!!!"),0) . "(" . mvindex(split(macro_commas,"!!!!!!!"),1) . ")")) \
 | lookup splunkadmins_macros title AS macroName, app AS app_name, splunk_server \
 | eval app_name2="global" \
-| search `comment("The original version just did an OUTPUTNEW definition, however this has the limitation that if 1 of the 5 macros found resolves, output stops. And this can result in missing macros. So this version over-matches but that appears to be the tradeoff...without making this even more complicated")` \
+| search ```The original version just did an OUTPUTNEW definition, however this has the limitation that if 1 of the 5 macros found resolves, output stops. And this can result in missing macros. So this version over-matches but that appears to be the tradeoff...without making this even more complicated``` \
 | lookup splunkadmins_macros title AS macroName, app AS app_name2, splunk_server OUTPUT definition AS definition2 \
 | lookup splunkadmins_macros title AS macroName, splunk_server OUTPUT definition AS definition3 \
 | eval definition=mvdedup(mvappend(definition,definition2,definition3)) \
 | fillnull definition value="macronotfound" \
 | nomv definition \
 | eval definition=" " . definition . " " \
-| search `comment("While an mvmap could replace per-macro that results in a multivalue output. Also replace doesn't handle a multivalued replacement argument so just replace the first macro if it exists with the definitions of all the macros, close enough for what we want")` \
+| search ```While an mvmap could replace per-macro that results in a multivalue output. Also replace doesn't handle a multivalued replacement argument so just replace the first macro if it exists with the definitions of all the macros, close enough for what we want``` \
 | eval search=if(isnotnull(macro_name),replace($fieldname$,mvindex(macro_name,0),definition),$fieldname$)
 iseval = 0
 
@@ -709,7 +709,7 @@ args = search_id
 definition = eval from=null(), username=null(), searchname2=null(), searchname=null()\
 | rex field=$search_id$ "(_rt)?(_?subsearch)*_?(?P<from>[^_]+)((_(?P<base64username>[^_]+))|(__(?P<username>[^_]+)))((__(?P<app>[^_]+)__(?P<searchname2>[^_]+))|(_(?P<base64appname>[^_]+)__(?P<searchname>[^_]+)))"\
 | rex field=$search_id$ "^_?(?P<from>SummaryDirector)"\
-| search `comment("Pattern appears to vary but remote_<hostname>_ is consistent along with the optional _subsearch, the _from can be <username>__ownername__appname__RMD for dashboards as one pattern, it can also be unixepoch (ad-hoc), or scheduler__username__appname (scheduled search), or  username__owner__(something)__dashboardview, among others. RMD values can be translated via audit.log, scheduler.log or remote_searches.log (if savedsearch_name is there)!")`\
+| search ```Pattern appears to vary but remote_<hostname>_ is consistent along with the optional _subsearch, the _from can be <username>__ownername__appname__RMD for dashboards as one pattern, it can also be unixepoch (ad-hoc), or scheduler__username__appname (scheduled search), or  username__owner__(something)__dashboardview, among others. RMD values can be translated via audit.log, scheduler.log or remote_searches.log (if savedsearch_name is there)!```\
 | fillnull from value="adhoc"\
 | eval searchname=coalesce(searchname,searchname2)\
 | eval type=case(from=="scheduler","scheduled",from=="SummaryDirector","acceleration",match(search_id,"^'?alertsmanager_"),"scheduled",isnotnull(searchname),"dashboard",1=1,"ad-hoc")
@@ -717,7 +717,7 @@ iseval = 0
 
 [base64decode(1)]
 args = afield
-definition = eval $afield$=null() | search `comment("As per https://docs.splunk.com/Documentation/Splunk/latest/Report/Createandeditreports usernames/apps can be base64 encrypted, remove the eval when ready to use this...decrypt2 (splunkbase) can be used to decrypt with (remove the backslashes): eval $afield$=$afield$ . \"===\" | decrypt field=$afield$ atob emit('$afield$')")`
+definition = eval $afield$=null() | search ```As per https://docs.splunk.com/Documentation/Splunk/latest/Report/Createandeditreports usernames/apps can be base64 encrypted, remove the eval when ready to use this...decrypt2 (splunkbase) can be used to decrypt with (remove the backslashes): eval $afield$=$afield$ . \"===\" | decrypt field=$afield$ atob emit('$afield$')```
 iseval = 0
 
 [dashboard_depends_filter1]
@@ -725,11 +725,11 @@ definition = ""
 iseval = 0
 
 [dashboard_depends_filter2]
-definition = search `comment("potentially a where clause to only filter when a certain number of tokens exist...")`
+definition = search ```potentially a where clause to only filter when a certain number of tokens exist...```
 iseval = 0
 
 [dashboard_depends_filter3]
-definition = search `comment("potentially a where clause to only filter when a certain number of tokens were matched or similar...")`
+definition = search ```potentially a where clause to only filter when a certain number of tokens were matched or similar...```
 iseval = 0
 
 [splunkadmins_wineventlog_index]
@@ -800,7 +800,7 @@ definition = eval definition=null(), datamodel3=null(), datamodel1=null(), datam
 | lookup splunkadmins_datamodels datamodel AS datamodel_res, splunk_server OUTPUTNEW definition\
 | nomv definition \
 | eval definition=" " . definition . " "\
-| search `comment("While an mvmap could replace per-datamodel that results in a multivalue output. Also replace doesn't handle a multivalued replacement argument so just replace the first macro if it exists with the definitions of all the datamodels")` \
+| search ```While an mvmap could replace per-datamodel that results in a multivalue output. Also replace doesn't handle a multivalued replacement argument so just replace the first macro if it exists with the definitions of all the datamodels``` \
 | eval search=if(isnotnull(datamodel_res),replace(search,mvindex(datamodel_res,0),definition),search)
 iseval = 0
 
@@ -875,7 +875,7 @@ iseval = 0
 
 [splunkadmins_shutdown_time_by_shc(3)]
 args = macroName, minTimeContingency, maxTimeContingency
-definition = search `comment("Send an exclusion list in terms of a search result for the time when any SH was shutdown")`\
+definition = search ```Send an exclusion list in terms of a search result for the time when any SH was shutdown```\
 index=_internal (`$macroName$`) sourcetype=splunkd `splunkadmins_splunkd_source` (CASE("Shutting down")) OR "Shutdown complete in" OR "Received shutdown signal." OR "Shutdown signal received" OR "master has instructed peer to restart" OR "Performing early shutdown tasks"\
 | eval message=coalesce(message,event_message)\
 | stats min(_time) AS logTime by message, host\

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -618,8 +618,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```The number of warnings about duplication seems unusually high and may require investigation``` \
-```The duplication warnings will occur with indexer acknowledgement enabled and indexer shutdowns. Other circumstances likely require some kind of investigation, the issue may also appear if the forwarder is having trouble getting CPU time...```\
+search = ```The number of warnings about duplication seems unusually high and may require investigation \
+The duplication warnings will occur with indexer acknowledgement enabled and indexer shutdowns. Other circumstances likely require some kind of investigation, the issue may also appear if the forwarder is having trouble getting CPU time...```\
 index=_internal sourcetype=splunkd (`splunkadmins_splunkuf_source`) NOT (`splunkenterprisehosts`) "duplication" `splunkadmins_unusual_duplication`\
 | search ```Exclude shutdown times``` AND NOT [`splunkadmins_shutdown_time(indexerhosts,60,60)`]\
 | stats count by host \
@@ -651,9 +651,9 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = ```Look for issues relating to CRC salt on any files...the universal forwarder settings may need tweaking to ensure the file is read as expected, or it may be a rolled file``` \
 index=_internal "You may wish to use larger initCrcLen for this sourcetype" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) `splunkadmins_crcsalt_initcrc`\
-```Attempt to exclude rolled files from the check by looking for the most common pattern (.1, .2, .10 or similar)``` \
-```This alert aims to find files where crcSalt = <SOURCE> might be required in the inputs.conf file or a tweak to the initCrcLen...```\
-```Regex for filename now replaces the default field extraction due to Windows based filenames containing spaces..```\
+```Attempt to exclude rolled files from the check by looking for the most common pattern (.1, .2, .10 or similar) \
+This alert aims to find files where crcSalt = <SOURCE> might be required in the inputs.conf file or a tweak to the initCrcLen...\
+Regex for filename now replaces the default field extraction due to Windows based filenames containing spaces..```\
 | rex "file=(?P<file>.+)\)\."\
 | regex file!="\.\d+$" \
 | eval message=coalesce(message,event_message)\
@@ -682,8 +682,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Detect universal forwarders that appear to be moving their clocks backwards/into the past or forwards, into the future. Timeshifting servers may need to be excluded from Splunk``` \
-```The string \"WARN TimeoutHeap - Either time adjusted forwards by, or event loop was descheduled for\" looks similar but tends to relate to a poorly performing server rather than a time shift...```\
+search = ```Detect universal forwarders that appear to be moving their clocks backwards/into the past or forwards, into the future. Timeshifting servers may need to be excluded from Splunk \
+The string "WARN TimeoutHeap - Either time adjusted forwards by, or event loop was descheduled for" looks similar but tends to relate to a poorly performing server rather than a time shift...```\
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) "Detected system time adjusted" OR "System time went " `splunkadmins_uf_timeshifting`\
 | rex "by (?P<timePeriod>\d+)ms\.$"\
 | rex "by (?P<timePeriodInSecs>[\d\.]+) seconds$"\
@@ -737,7 +737,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Data should not appear from the future...this alert finds that data so it can be investigated``` ```This query could be | tstats count, max(_time), min(_time) where index=* earliest=+5m latest=+10y groupby index, sourcetype, _time, _indextime span=1d, and then drop the field named 'ahead', but in 8.2.5 this is slower than the index= version``` \
+search = ```Data should not appear from the future...this alert finds that data so it can be investigated. This query could be | tstats count, max(_time), min(_time) where index=* earliest=+5m latest=+10y groupby index, sourcetype, _time, _indextime span=1d, and then drop the field named 'ahead', but in 8.2.5 this is slower than the index= version``` \
 index=* earliest=+5m latest=+10y `splunkadmins_future_dated`\
 | eval ahead=abs(now() - _time)\
 | eval indextime=_indextime\
@@ -772,17 +772,17 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Timestamp parsing has failed, and it doesn't appear to be related to the event been broken due to having too many lines, that is a separate alert that may trigger a timestamp parsing issue (excluded from this alert as that issue needs to be resolved first)``` \
-```Please note that you may see this particular warning on data that is sent to the nullQueue using a transforms.conf. Obviously you won't see this in the index but you will see the warning because the time parsing occurs before the transforms.conf occurs```\
-```This alert now checks for at least 2 failures, and header entries can often trigger 2 entries in the log files about timestamp parsing failures...```\
-```Finally one strange edge case is a newline inserted into the log file (by itself with no content before/afterward) can trigger the warning but nothing will get indexed, multiline_event_extra_waittime, time_before_close and EVENT_BREAKER can resolve this edge case```\
+search = ```Timestamp parsing has failed, and it doesn't appear to be related to the event been broken due to having too many lines, that is a separate alert that may trigger a timestamp parsing issue (excluded from this alert as that issue needs to be resolved first) \
+Please note that you may see this particular warning on data that is sent to the nullQueue using a transforms.conf. Obviously you won't see this in the index but you will see the warning because the time parsing occurs before the transforms.conf occurs\
+This alert now checks for at least 2 failures, and header entries can often trigger 2 entries in the log files about timestamp parsing failures...\
+Finally one strange edge case is a newline inserted into the log file (by itself with no content before/afterward) can trigger the warning but nothing will get indexed, multiline_event_extra_waittime, time_before_close and EVENT_BREAKER can resolve this edge case```\
 index=_internal sourcetype=splunkd ("Failed to parse timestamp" "Defaulting to timestamp of previous event") OR "Breaking event because limit of " OR "outside of the acceptable time window" (`splunkadmins_splunkd_source`) (`indexerhosts`) OR (`heavyforwarderhosts`) `splunkadmins_failuretoparse_timestamp`\
 | bin _time span=`splunkadmins_failuretoparse_timestamp_binperiod` \
 | eval host=data_host, source=data_source, sourcetype=data_sourcetype\
 | rex "source::(?P<source>[^|]+)\|host::(?P<host>[^|]+)\|(?P<sourcetype>[^|]+)" \
 | eventstats count(eval(isnotnull(data_host))) AS hasBrokenEventOrTuncatedLine, count(eval(searchmatch("outside of the acceptable time window"))) AS outsideTimewindow by _time, host, source, sourcetype\
 | where hasBrokenEventOrTuncatedLine=0 AND isnull(data_host) AND NOT searchmatch("outside of the acceptable time window")\
-| search ```To investigate further we want the previous timestamp that Splunk used for the event in question, that way we can see what it looks like in raw format...```\
+```To investigate further we want the previous timestamp that Splunk used for the event in question, that way we can see what it looks like in raw format...```\
 | rex "Defaulting to timestamp of previous event \((?P<previousTimeStamp>[^)]+)"\
 | eval previousTimeStamp=strptime(previousTimeStamp, "%a %b %d %H:%M:%S %Y")\
 | stats count, min(_time) AS firstSeen, max(_time) AS mostRecent, first(previousTimeStamp) AS recentExample, sum(outsideTimewindow) AS outsideTimewindow by host, sourcetype, source\
@@ -794,7 +794,7 @@ index=_internal sourcetype=splunkd ("Failed to parse timestamp" "Defaulting to t
 | eval invesDataSource=if(mvcount(invesDataSource)>1,mvjoin(invesDataSource,"\" OR source=\""),invesDataSource)\
 | eval invesDataSource = "source=\"" + invesDataSource + "\""\
 | eval invesDataSource = replace(invesDataSource, "\\\\", "\\\\\\\\")\
-| eval investigationQuery="```\"The investigation query may find zero data if the data was sent to the null queue by a transforms.conf as the time parsing occurs before the transforms occur. If this source/sourcetype has a null queue you may need to exclude it from this alert\``` ```\"Note that the host= can be inaccurate if host overrides are in use in transforms.conf, if this query finds no results remove host=...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" " . invesDataSource . " earliest=" . recentExample . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")" \
+| eval investigationQuery="```The investigation query may find zero data if the data was sent to the null queue by a transforms.conf as the time parsing occurs before the transforms occur. If this source/sourcetype has a null queue you may need to exclude it from this alert. Note that the host= can be inaccurate if host overrides are in use in transforms.conf, if this query finds no results remove host=...``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" " . invesDataSource . " earliest=" . recentExample . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")" \
 | eval mostRecent=strftime(mostRecent, "%+"), firstSeen=strftime(firstSeen, "%+")\
 | eval outsideAcceptableTimeWindow=if(outsideTimewindow!=0,"Timestamp parsing failed due to been outside the acceptable time window","No")\
 | fields - recentExample, invesEnd, invesDataSource, outsideTimewindow\
@@ -893,8 +893,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```If the replication queue is full, then depending on the replication factor this can stop / slow indexing. Note this alert has been set to find many results to remove false alarms...``` \
-```Unfortunately this setting is not tunable, at the time of writing (7.0.0) the queue size is 20. If the \"has room now\" appears shortly afterward this is not an issue.```\
+search = ```If the replication queue is full, then depending on the replication factor this can stop / slow indexing. Note this alert has been set to find many results to remove false alarms... \
+Unfortunately this setting is not tunable, at the time of writing (7.0.0) the queue size is 20. If the "has room now" appears shortly afterward this is not an issue.```\
 index=_internal `indexerhosts` "replication queue for " "full" sourcetype=splunkd (`splunkadmins_splunkd_source`)\
 | rename peer AS guid \
 | join guid [| rest /services/search/distributed/peers `splunkadmins_restmacro` | fields guid peerName]\
@@ -978,7 +978,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | tstats summariesonly=t count WHERE index="*" by splunk_server _time span=10m\
-| search ```If the balance of data between indexer cluster members becomes very unbalanced then the searches tend to spend more CPU on a particular indexer / search peer and this eventually creates issues```\
+```If the balance of data between indexer cluster members becomes very unbalanced then the searches tend to spend more CPU on a particular indexer / search peer and this eventually creates issues```\
 | sort _time \
 | eventstats sum(count) AS totalCountForTime, dc(splunk_server) AS indexers by _time \
 | eval perc=round((count/totalCountForTime)*100,2) \
@@ -1006,15 +1006,15 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events...``` \
-```If running Splunk 7 or newer than refer to the monitoring console Indexing -> Inputs -> Data Quality```\
+search = ```The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events... \
+If running Splunk 7 or newer than refer to the monitoring console Indexing -> Inputs -> Data Quality```\
 index=_internal AggregatorMiningProcessor "Breaking event because limit of" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkadmins_weekly_brokenevents`\
 | rex "Breaking event because limit of (?P<curlimit>\d+)" \
 | stats max(_time) AS mostRecent, min(_time) AS firstSeen, count by data_sourcetype, data_host, curlimit\
 | eval longerThan=curlimit-1\
 | eval invesLatest = if(mostRecent==firstSeen,mostRecent+1,mostRecent)\
 | rename data_sourcetype AS sourcetype, data_host AS host\
-| eval investigationQuery="```\"If no results are found prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" linecount>" . longerThan . " earliest=" . firstSeen . " latest=" . invesLatest\
+| eval investigationQuery="```If no results are found prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" linecount>" . longerThan . " earliest=" . firstSeen . " latest=" . invesLatest\
 | fields - firstSeen, longerThan, invesLatest\
 | eval mostRecent=strftime(mostRecent, "%+")\
 | sort - count
@@ -1039,9 +1039,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)```\
-```If running Splunk 7 or newer than refer to the Monitoring Console, Indexing -> Inputs -> Data Quality```\
-```If you are in a (very) performance sensitive environment you might want to remove the rex/eval lines for the data_host field and let the admin update the inves query manually```\
+search = ```The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)\
+Also refer to the Monitoring Console, Indexing -> Inputs -> Data Quality\
+If you are in a (very) performance sensitive environment you might want to remove the rex/eval lines for the data_host field and let the admin update the investigation query manually```\
 index=_internal "Truncating line because limit of" sourcetype=splunkd (`splunkadmins_splunkd_source`) (`heavyforwarderhosts`) OR (`indexerhosts`) `splunkadmins_weekly_truncated`\
 | rex "Truncating line because limit of (?P<curlimit>\d+) bytes.*with a line length >= (?P<approxlinelength>\S+)" \
 | rex field=data_host "(?P<data_host>[^\.]+)"\
@@ -1054,7 +1054,7 @@ index=_internal "Truncating line because limit of" sourcetype=splunkd (`splunkad
 | eval invesLastSeen=if(firstSeen==lastSeen,lastSeen+1,lastSeen)\
 | eval firstSeen=firstSeen-10\
 | eval invesLastSeen=invesLastSeen+10\
-| eval investigationQuery="```\"Find examples where the truncation limit has been reached\``` ```\"The earliest/latest time is based on the warning messages in the Splunk logs, they may need customisation!\``` index=* sourcetype=" . sourcetype . " " . hostList . " earliest=" . firstSeen . " latest=" . invesLastSeen . " | where len(_raw)=" . curlimit\
+| eval investigationQuery="```Find examples where the truncation limit has been reached. The earliest/latest time is based on the warning messages in the Splunk logs, they may need customisation!``` index=* sourcetype=" . sourcetype . " " . hostList . " earliest=" . firstSeen . " latest=" . invesLastSeen . " | where len(_raw)=" . curlimit\
 | sort - count\
 | eval lastSeen=strftime(lastSeen, "%+")\
 | table sourcetype, curlimit, count, avgApproxLineLength, maxApproxLineLength, lastSeen, investigationQuery\
@@ -1087,19 +1087,19 @@ index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) (`indexerhost
 OR "is too far away from the previous event's time" \
 OR "is suspiciously far away from the previous event's time" `splunkadmins_valid_timestamp_invalidparsed`\
 | rex "source::(?P<source>[^|]+)\|host::(?P<host>[^|]+)\|(?P<sourcetype>[^|]+)"\
-| search ```The goal of this part of the search was to obtain the messages that are relating to this particular host/source/sourcetype, however since the message includes a time we cannot uses values(message) without getting a huge number of values, therefore we use cluster to obtain the unique values. Since we want the original start/end times we use labelonly=true```\
+ ```The goal of this part of the search was to obtain the messages that are relating to this particular host/source/sourcetype, however since the message includes a time we cannot uses values(message) without getting a huge number of values, therefore we use cluster to obtain the unique values. Since we want the original start/end times we use labelonly=true```\
 | cluster labelonly=true \
 | eval message=coalesce(message,event_message)\
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen, first(message) AS message by host, source, sourcetype, cluster_label\
-| search ```While 'A possible timestamp match (...) is outside of the acceptable time window' and 'Time parsed (...) is too far away from the previous event's time', result in the current indexing time been used, the 'Accepted time (...) is suspiciously far away from the previous event's time' is accepted and therefore we need to expand the investigation query time to include this time range as well!``` \
+```While "A possible timestamp match (...) is outside of the acceptable time window" and "Time parsed (...) is too far away from the previous event's time", result in the current indexing time been used, the "Accepted time (...) is suspiciously far away from the previous event's time" is accepted and therefore we need to expand the investigation query time to include this time range as well!``` \
 | rex field=message "Accepted time \((?P<acceptedTime>[^\)]+)"\
 | eval acceptedTime=strptime(acceptedTime, "%a %b %d %H:%M:%S %Y")\
 | eval firstSeen=if(acceptedTime<firstSeen,acceptedTime,firstSeen)\
-| search ```Now that we have the first message for each labelled cluster, we now take all relevant message per host/source/sourcetype```\
+```Now that we have the first message for each labelled cluster, we now take all relevant message per host/source/sourcetype```\
 | stats values(acceptedTime) AS acceptedTime, sum(count) AS count, min(firstSeen) AS firstSeen, max(lastSeen) AS lastSeen, values(message) AS message by host, source, sourcetype\
 | eval invesEnd=if(lastSeen=firstSeen,round(lastSeen+1),round(lastSeen)), invesStart=floor(firstSeen)\
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\")\
-| eval investigationQuery="```\"Please note that this query may need to be narrowed down further before running it, this is an example only...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" earliest=" . invesStart . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"\
+| eval investigationQuery="```Please note that this query may need to be narrowed down further before running it, this is an example only...``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" earliest=" . invesStart . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"\
 | eval firstSeen=strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")\
 | table host, source, sourcetype count, firstSeen, lastSeen, message, investigationQuery\
 | sort - count
@@ -1191,7 +1191,7 @@ index=_internal `searchheadhosts` sourcetype=scheduler NOT "The 'require' comman
 | rex "app=\"(?P<app>[^\"]+)\""\
 | eval message=coalesce(message,event_message)\
 | fillnull message\
-| search ```The below 3 lines will catch map/lookup errors or similar that look like message=\"Error in 'map': Did not find value for required attribute 'attr'.\". No actions executed. This may or may not be a good thing...``` \
+| search ```The below 3 lines will catch map/lookup errors or similar that look like message="Error in 'map': Did not find value for required attribute 'attr'.". No actions executed. This may or may not be a good thing...``` \
 | rex "- savedsearch_id=\"(?P<user2>[^;]+);(?P<app2>[^;]+);(?P<savedsearch_name_2>[^\"]+)" \
 | eval savedsearch_name=coalesce(savedsearch_name,savedsearch_name_2), app=coalesce(app,app2), user=coalesce(user,user2) \
 | fillnull status value="error" \
@@ -1452,9 +1452,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```The listed users have reached the maximum disk quota, they may be unaware so it is best to let them know about this issue...``` \
-```Note that the REST API call accesses the jobs list which can expire for ad-hoc jobs in 10 minutes, so this may find zero results. The status.csv inside the dispatch directory records the size per job but it is not indexed by Splunk so either this alert needs to run very often or it will sometimes run after the issue has occurred and send an empty top 10 jobs list...```\
-```The introspection index version is called SearchHeadLevel - Users exceeding the disk quota introspection, it is not search head specific but it is also less accurate for disk space used```\
+search = ```The listed users have reached the maximum disk quota, they may be unaware so it is best to let them know about this issue... \
+Note that the REST API call accesses the jobs list which can expire for ad-hoc jobs in 10 minutes, so this may find zero results. The status.csv inside the dispatch directory records the size per job but it is not indexed by Splunk so either this alert needs to run very often or it will sometimes run after the issue has occurred and send an empty top 10 jobs list...\
+The introspection index version is called SearchHeadLevel - Users exceeding the disk quota introspection, it is not search head specific but it is also less accurate for disk space used```\
 index=_internal sourcetype=splunkd `splunkenterprisehosts` (`splunkadmins_splunkd_source`) "maximum disk usage quota" `splunkadmins_users_exceeding_diskquota`\
 | stats max(_time) AS mostRecent by username, reason, host\
 | eval mostRecent = strftime(mostRecent, "%+")\
@@ -1541,7 +1541,7 @@ index=_internal DateParserVerbose "Accepted time format has changed" sourcetype=
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen by host, source, sourcetype, message\
 | eval invesMaxTime=if(firstSeen=lastSeen,lastSeen+1,lastSeen)\
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\")\
-| eval potentialInvestigationQuery="```\"If no results are found, prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\``` sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" host=" . host . " earliest=" . firstSeen . " latest=" . invesMaxTime . " | eval start=substr(_raw, 0, 30) | cluster field=start"\
+| eval potentialInvestigationQuery="```If no results are found, prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...``` sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" host=" . host . " earliest=" . firstSeen . " latest=" . invesMaxTime . " | eval start=substr(_raw, 0, 30) | cluster field=start"\
 | eval firstSeen=strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")\
 | fields - invesMaxTime, invesDataSource\
 | sort - count
@@ -1593,8 +1593,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```These searches were scheduled to run at a particular time but the actual run time was more than X seconds later, which might indicate a search head performance issue``` \
-```In the environment this search was created on restarts are not overly common so we assume any restart might relate to a scheduling delay to prevent false alarms from the alert. This may need further tuning or you may wish to remove the where clause in this if you want more alerting.```\
+search = ```These searches were scheduled to run at a particular time but the actual run time was more than X seconds later, which might indicate a search head performance issue \
+In the environment this search was created on restarts are not overly common so we assume any restart might relate to a scheduling delay to prevent false alarms from the alert. This may need further tuning or you may wish to remove the where clause in this if you want more alerting.```\
 index=_internal `splunkenterprisehosts` sourcetype=scheduler app=* scheduled_time=* source=*scheduler.log\
 | search ```Exclude time periods where shutdowns were occurring``` AND NOT [`splunkadmins_shutdown_list(splunkenterprisehosts,600,600)`]\
 | eval time=strftime(_time,"%+") \
@@ -1655,8 +1655,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```The indexer is freezing buckets due to disk space pressure before the frozenTimePeriodInSecs limit has been reached, this could be a problem if it is not expected...```\
-```_introspection defaults to size based so exclude it``` \
+search = ```The indexer is freezing buckets due to disk space pressure before the frozenTimePeriodInSecs limit has been reached, this could be a problem if it is not expected...\
+_introspection defaults to size based so exclude it``` \
 index=_internal `indexerhosts` sourcetype=splunkd (`splunkadmins_splunkd_source`) BucketMover "will attempt to freeze" NOT "because frozenTimePeriodInSecs=" \
 `splunkadmins_bucketfrozen`\
 | rex field=bkt "(rb_|db_)(?P<newestDataInBucket>\d+)_(?P<oldestDataInBucket>\d+)"\
@@ -1710,8 +1710,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Core dumps are disabled, if a crash occurs the Splunk Support team might not be able to assist without the core dump```\
-```https://answers.splunk.com/answers/223838/why-are-my-ulimits-settings-not-being-respected-on.html applies to core limits so if the server has been rebooted the init.d may need a ulimit -Hc/Sc setting for this as well...```\
+search = ```Core dumps are disabled, if a crash occurs the Splunk Support team might not be able to assist without the core dump\
+https://answers.splunk.com/answers/223838/why-are-my-ulimits-settings-not-being-respected-on.html applies to core limits so if the server has been rebooted the init.d may need a ulimit -Hc/Sc setting for this as well...```\
 index=_internal "WARN  ulimit" "Core file generation disabled" `splunkenterprisehosts` sourcetype=splunkd (`splunkadmins_splunkd_source`) \
 | stats max(_time) AS mostRecentlySeen by host\
 | eval mostRecentlySeen = strftime(mostRecentlySeen, "%+")
@@ -1754,8 +1754,8 @@ search = | tstats count groupby host, source\
 | search ```Ignore any files requested by the macro, i.e. source!= or host!= or similar...``` `splunkadmins_permissions`\
 | stats sum(count) AS count, min(firstSeen) AS firstSeen, max(mostRecent) AS mostRecent, values(insufficientpermissions) AS insufficientpermissions, values(hint) AS hint by host, source \
 | search ```If we have an insufficient permissions error, did we see no data from our tstats command?``` insufficientpermissions="true" NOT count=* `splunkadmins_insufficient_permissions`\
-    ```At this point if we see an insufficient permissions line, and we cannot see a result from the tstats showing indexed data from that file, then we have an issue, if not there is no issue with permisisons!``` \
-    ```Insufficient permissions to read file + hint: No such file or directory when the file exists on a Splunk enterprise instance might require TAILING_SKIP_READ_CHECK = 1 in the splunk-launch.conf refer to splunk support for more info``` \
+    ```At this point if we see an insufficient permissions line, and we cannot see a result from the tstats showing indexed data from that file, then we have an issue, if not there is no issue with permisisons! \
+    Insufficient permissions to read file + hint: No such file or directory when the file exists on a Splunk enterprise instance might require TAILING_SKIP_READ_CHECK = 1 in the splunk-launch.conf refer to splunk support for more info``` \
 | eval invesSource=replace(source, "\\\\", "\\\\\\\\") \
 | addinfo \
 | eval investigationQuery="index=_internal \"Insufficient permissions to read file\" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) earliest=" . info_min_time . " latest=" . info_max_time . " host=" . host . " file=\"'" . invesSource . "'\""\
@@ -1783,8 +1783,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```A paused TCP output processor is a potential indicator of an index performance issue, you may wish to ignore the shorter pause times such as 10 seconds if this is creating too many alerts...```\
-```On the indexer side you may see 'WARN TcpInputProc - Stopping all listening ports. Queues blocked for more than...' OR 'WARN TcpInputProc - Started listening on tcp ports. Queues unblocked', if there are indexer performance issues...```\
+search = ```A paused TCP output processor is a potential indicator of an index performance issue, you may wish to ignore the shorter pause times such as 10 seconds if this is creating too many alerts...\
+On the indexer side you may see 'WARN TcpInputProc - Stopping all listening ports. Queues blocked for more than...' OR 'WARN TcpInputProc - Started listening on tcp ports. Queues unblocked', if there are indexer performance issues...```\
 index=_internal "paused" "data flow" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) `splunkadmins_tcpoutput_paused`\
 | search ```Exclude shutdown times``` AND NOT [`splunkadmins_shutdown_time(indexerhosts,60,60)`]\
 | rex "has been blocked for (blocked_seconds=)?(?P<timeperiod>\d+)"\
@@ -1814,8 +1814,8 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | dbinspect index=* state=warm\
-| search ```Once the warmdb bucket count is reached then the buckets are moved to cold, this may be an issue if incorrectly configured, this alert warns in advance if we get close to the limit```\
-```This might be a bug in 6.5.2 but the buckets are printed twice by dbinspect in some cases...``` `splunkadmins_warmdbcount`\
+| search ```Once the warmdb bucket count is reached then the buckets are moved to cold, this may be an issue if incorrectly configured, this alert warns in advance if we get close to the limit\
+This might be a bug in 6.5.2 but the buckets are printed twice by dbinspect in some cases...``` `splunkadmins_warmdbcount`\
 | dedup bucketId, splunk_server\
 | stats count AS theCount by index, splunk_server\
 | stats avg(theCount) AS averageCount, max(theCount) AS maxCount, min(theCount) AS minCount, values(splunk_server) by index\
@@ -1875,15 +1875,15 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```If we see a failed to get LDAP user 'username' from any configured servers then that is a sign the user is no longer in the company. However if there is also a message of Couldn't find matching groups for that same user it is more likely that they exist but just do not have access to Splunk```\
-```If you see this alert fire, than you probably need to cleanup the (for example) /opt/splunk/etc/users/... directory on each search head due to a user leaving/becoming disabled in LDAP. Alternatively they have a savedsearch/dashboard that you can find in the .meta files on the search head(s)```\
+search = ```If we see a failed to get LDAP user 'username' from any configured servers then that is a sign the user is no longer in the company. However if there is also a message of Couldn't find matching groups for that same user it is more likely that they exist but just do not have access to Splunk\
+If you see this alert fire, than you probably need to cleanup the (for example) /opt/splunk/etc/users/... directory on each search head due to a user leaving/becoming disabled in LDAP. Alternatively they have a savedsearch/dashboard that you can find in the .meta files on the search head(s)```\
 index=_internal `searchheadhosts` "Failed to get LDAP user=\"" OR "Couldn't find matching groups for user=" OR (HTTPAuthManager "SSO failed - User does not exist") sourcetype=splunkd (`splunkadmins_splunkd_source`)\
 | eval message=coalesce(message,event_message)\
 | dedup message \
 | rex "SSO failed - User does not exist: (?P<user>\S+)"\
 | stats count, values(message) AS messages, values(component), AS components values(log_level), max(_time) AS lastSeen by user, host\
-| search ```count=1 eliminates users who are failing to login...if a user is active in LDAP but fails to login we should not not get a 'Couldn't find matching groups for user' line in the logs```\
-```If we are using a single sign on system and a user without any groups attempts sign on we should see the SSO failed - User does not exist: <username> message```\
+| search ```count=1 eliminates users who are failing to login...if a user is active in LDAP but fails to login we should not not get a "Couldn't find matching groups for user" line in the logs\
+If we are using a single sign on system and a user without any groups attempts sign on we should see the "SSO failed - User does not exist: <username> message"```\
 | where user!="undefined" AND user!="nobody" AND like(messages,"Failed to get LDAP user%") AND NOT like(messages,"SSO failed - User does not exist%")\
 | table user, messages, lastSeen, host\
 | eval lastSeen=strftime(lastSeen, "%+")
@@ -2062,9 +2062,9 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/saved/searches `splunkadmins_restmacro`\
-| search ```The problem with alerts that are configured privately is that no one beyond the author can use the results link and non-admins cannot even see the alert in Splunk!```\
-```Therefore we find anything that emails that is not shared correctly *and* anything that uses a script as often the script will include a results link.```\
-```The idea here is to let the end user know so they can share it appropriately, the noop search is excluded to remove scheduled views from this list```\
+| search ```The problem with alerts that are configured privately is that no one beyond the author can use the results link and non-admins cannot even see the alert in Splunk!\
+Therefore we find anything that emails that is not shared correctly *and* anything that uses a script as often the script will include a results link.\
+The idea here is to let the end user know so they can share it appropriately, the noop search is excluded to remove scheduled views from this list```\
 is_scheduled=1 disabled=0 eai:acl.sharing!="global" eai:acl.sharing!="app" search!="| noop" actions!="" `splunkadmins_scheduled_incorrectsharing`\
 | eval numberOfEmailed = mvcount(split('action.email.to',"@"))-1\
 | table title, eai:acl.app, author, eai:acl.sharing, actions, action.email.to, numberOfEmailed\
@@ -2096,8 +2096,8 @@ search = | rest/servicesNS/-/-/data/ui/views `splunkadmins_restmacro` | regex ea
 | rex field=eai:data "(?s)(?P<theSearch><search(?!String)[^>]*>[^<]*<query>.*?)<\/query>" max_match=200 \
 | mvexpand theSearch \
 | rex field=theSearch "(?s)<search(?P<searchInfo>[^>]*)>[^<]*<query>(?P<theQuery>.*)" \
-| search searchInfo!="*base*" ```Exclude queries which have a base, in general they will not have a earliest/latesttime so this gets confusing```\
-```It might be possible to use mvzip / mvexpand or mvindex to match the correct earliesttime/latesttime with each search query but it proved extremely difficult. So just keeping this as-is as the dashboard needs to be reviewed if it has too many realtime searches anyway```\
+| search searchInfo!="*base*" ```Exclude queries which have a base, in general they will not have a earliest/latesttime so this gets confusing\
+It might be possible to use mvzip / mvexpand or mvindex to match the correct earliesttime/latesttime with each search query but it proved extremely difficult. So just keeping this as-is as the dashboard needs to be reviewed if it has too many realtime searches anyway```\
 | rex field=eai:data "(?s)<earliest(Time)?>(?P<earliesttime>[^<]+)" max_match=200 \
 | rex field=eai:data "(?s)<latest(Time)?>(?P<latesttime>[^<]+)" max_match=200 \
 | table title, eai:appName, searchInfo, theQuery,eai:acl.owner, eai:acl.sharing, label, earliesttime, latesttime, splunk_server
@@ -2123,9 +2123,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Detect when transparent huge pages is enabled on a Linux server, it should be disabled.```\
-```Redhat Linux has an issue where the transparent huge pages setting changes after Splunk starts if the server was rebooted, check /sys/kernel/mm/transparent_hugepage to confirm...```\
-```| rest /services/server/sysinfo is an alternative if you want the current search head + indexers, but this will ignore other search heads...```\
+search = ```Detect when transparent huge pages is enabled on a Linux server, it should be disabled.\
+Redhat Linux has an issue where the transparent huge pages setting changes after Splunk starts if the server was rebooted, check /sys/kernel/mm/transparent_hugepage to confirm...\
+| rest /services/server/sysinfo is an alternative if you want the current search head + indexers, but this will ignore other search heads...```\
 index=_internal "Linux transparent hugepage support, enabled=" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkenterprisehosts` enabled!="never"\
 | eval error="This configuration of transparent hugepages is known to cause serious runtime problems with Splunk. Typical symptoms include generally reduced performance and catastrophic breakdown in system resp\
 onsiveness under high memory pressure. Please fix by setting the values for transparent huge pages to \"madvise\" or preferably \"never\" via sysctl, kernel boot parameters, or other method recommended by your Linux distribution."\
@@ -2157,7 +2157,7 @@ search = | tstats max(_time) AS mostRecentlySeen, max(_indextime) AS mostRecentl
     groupby source, sourcetype, index, host\
 | search ```Find data that appears to be logged in the past, this may indicate poor timestamp parsing (or we're just ingesting really old data``` `splunkadmins_olddata`\
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\"), invesLatestTime=mostRecentlySeen+1, invesLatestIndexTime=mostRecentlyIndexed+1\
-| eval investigationQuery="```\"Narrow down to the older part of the timeline after this query runs to see the potential issue...\``` index=" . index . " source=\"" . invesDataSource . "\" sourcetype=\"" . sourcetype . "\" host=" . host . " earliest=" . earliestSeen . " latest=" . invesLatestTime . " _index_earliest=" . earliestIndexTime . " _index_latest=" . invesLatestIndexTime . " | eval indextime=strftime(_indextime, \"%+\")" \
+| eval investigationQuery="```Narrow down to the older part of the timeline after this query runs to see the potential issue...``` index=" . index . " source=\"" . invesDataSource . "\" sourcetype=\"" . sourcetype . "\" host=" . host . " earliest=" . earliestSeen . " latest=" . invesLatestTime . " _index_earliest=" . earliestIndexTime . " _index_latest=" . invesLatestIndexTime . " | eval indextime=strftime(_indextime, \"%+\")" \
 | eval mostRecentlySeen=strftime(mostRecentlySeen, "%+"), mostRecentlyIndexed=strftime(mostRecentlyIndexed, "%+")\
 | sort index, host, sourcetype\
 | table index, source, sourcetype, host, mostRecentlySeen, mostRecentlyIndexed, count, investigationQuery
@@ -2236,7 +2236,7 @@ request.ui_dispatch_view = search
 search = ```sendmodalert or sendalert errors and warnings may be an issue relating to the creation of alerts via a script```\
 index=_internal `splunkenterprisehosts` ("ERROR sendmodalert" action) OR ("WARN sendmodalert" action) OR "Error in 'sendalert' command" sourcetype=splunkd (`splunkadmins_splunkd_source`)\
 ```If you need more context on the above errors add this snippet into the above search (remove the \\):\
-OR \"sendmodalert - Invoking modular alert action\"\
+OR "sendmodalert - Invoking modular alert action"\
 ```\
 `splunkadmins_sendmodalert_errors`\
 | rex field=results_file "[/\\\]dispatch[/\\\](?P<sid>[^/]+)"\
@@ -2352,7 +2352,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = ```Replication status failure on a search head, the search head may require a restart or investigation...```\
-index=_internal "because replication was unsuccessful. replicationStatus Failed failure info:" OR "replicateDelta: failed for" OR (ERROR DistributedBundleReplicationManager) OR (WARN DistributedBundleReplicationManager NOT "however it took too long") ```These are deprecated in Splunk 9, NOT \"replicationWhitelist in distsearch.conf is deprecated\" NOT \"replicationBlacklist in distsearch.conf is deprecated\"``` ```This is confirmed as an invalid warning message in Splunk 9``` NOT "Failed to touch bundle=, checksum=0 (manual preparation): No such file or directory" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkenterprisehosts` `splunkadmins_repfailures`\
+index=_internal "because replication was unsuccessful. replicationStatus Failed failure info:" OR "replicateDelta: failed for" OR (ERROR DistributedBundleReplicationManager) OR (WARN DistributedBundleReplicationManager NOT "however it took too long") ```These are deprecated in Splunk 9, NOT "replicationWhitelist in distsearch.conf is deprecated" NOT "replicationBlacklist in distsearch.conf is deprecated". This is confirmed as an invalid warning message in Splunk 9``` NOT "Failed to touch bundle=, checksum=0 (manual preparation): No such file or directory" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkenterprisehosts` `splunkadmins_repfailures`\
 | search ```Exclude shutdown times``` AND NOT [`splunkadmins_shutdown_keyword(indexerhosts,180,180)`]\
 | eval event_message=coalesce(event_message,message) \
 | stats count, max(_time) AS mostRecent by host, event_message \
@@ -2516,9 +2516,9 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | tstats max(linecount) AS maxLineCount, min(_time) AS firstSeen, max(_time) AS mostRecent, values(host) AS hosts, count AS occurrenceCount where index=*, linecount>250 groupby sourcetype\
-| search ```This search detects sourcetypes with greater than 250 lines which have SHOULD_LINEMERGE set to true, this might cause blocking in the indexer aggregation queue if there are a large number```\
-```of events with hundreds of lines or very large events such as >5000 lines of data. This alert is designed to give hints about where SHOULD_LINEMERGE=false / LINE_BREAKER=... might be more appropriate```\
-```Note that the REST API will return every instance of sourcetype, it's not quite as accurate a btool so this can generate false alarms if there are multiple props.conf definitions of a sourcetype```\
+| search ```This search detects sourcetypes with greater than 250 lines which have SHOULD_LINEMERGE set to true, this might cause blocking in the indexer aggregation queue if there are a large number\
+of events with hundreds of lines or very large events such as >5000 lines of data. This alert is designed to give hints about where SHOULD_LINEMERGE=false / LINE_BREAKER=... might be more appropriate\
+Note that the REST API will return every instance of sourcetype, it's not quite as accurate a btool so this can generate false alarms if there are multiple props.conf definitions of a sourcetype```\
 `splunkadmins_multiline_linemerge`\
 | join [| rest `splunkindexerhostsvalue` /servicesNS/-/-/configs/conf-props\
 | fields title SHOULD_LINEMERGE\
@@ -2580,11 +2580,11 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Detect search head issues related to extended search head downtime, in particular ConfReplication issues or KV store replication issues```\
-```KVStore - http://docs.splunk.com/Documentation/Splunk/latest/Admin/ResyncKVstore , ConfReplication - http://docs.splunk.com/Documentation/Splunk/latest/DistSearch/HowconfrepoworksinSHC#Replication_synchronization_issues```\
-```The search head cluster captain is disconnected can relate to a SH cluster restart *or* if outside a rolling restart this may require a restart of the problematic search head...```\
-```In addition to this you could also look for \"Error pushing configurations to captain\" consecutiveErrors>1 , this would also hint at a potential issue although a small number of consecutive errors appears to be normal...```\
-```If you see the message \"Consider performing a destructive configuration resync on this search head cluster member\", then it's a real issue and often requires manual intervention...``` \
+search = ```Detect search head issues related to extended search head downtime, in particular ConfReplication issues or KV store replication issues\
+KVStore - http://docs.splunk.com/Documentation/Splunk/latest/Admin/ResyncKVstore , ConfReplication - http://docs.splunk.com/Documentation/Splunk/latest/DistSearch/HowconfrepoworksinSHC#Replication_synchronization_issues\
+The search head cluster captain is disconnected can relate to a SH cluster restart *or* if outside a rolling restart this may require a restart of the problematic search head...\
+In addition to this you could also look for \"Error pushing configurations to captain\" consecutiveErrors>1 , this would also hint at a potential issue although a small number of consecutive errors appears to be normal...\
+If you see the message \"Consider performing a destructive configuration resync on this search head cluster member\", then it's a real issue and often requires manual intervention...``` \
 index=_internal `searchheadhosts` "Local KV Store has replication issues" OR ("ConfReplicationThread" "captain") OR ("SHCMasterHTTPProxy" "Low Level http request" NOT "did not satisfy regex" NOT "does not exist" NOT "peer already has artifact" NOT "has inflight replications" NOT ("failed on report target request" "not found")) sourcetype=splunkd (`splunkadmins_splunkd_source`) \
 | regex "\S+\s+\S+\s+\S+\s+(ERROR|WARN)" \
 | eval search_head=host \
@@ -2781,7 +2781,7 @@ index=_internal "Too many events" (`indexerhosts`) OR (`heavyforwarderhosts`) `s
 | rex "Too many events \((?P<number>[0-9]+.)"\
 | rename data_host AS host, data_sourcetype AS sourcetype, data_source AS source\
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\"), invesStartTime=floor(_time)\
-| eval investigationQuery="```\"You will need to set the time settings manually as the log does not provide the parsed time, only the indexed time the issue occurred at...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" _index_earliest=" . invesStartTime\
+| eval investigationQuery="```You will need to set the time settings manually as the log does not provide the parsed time, only the indexed time the issue occurred at...``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" _index_earliest=" . invesStartTime\
 | eval message=coalesce(message,event_message)\
 | table host, sourcetype, source, number, cluster_count, message, _time, investigationQuery
 disabled = 1
@@ -2806,8 +2806,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```The main goal of this alert errors which might not appear in splunkd.log but are critical to keeping the kvstore running on the search heads. Please check the mongod.log file for further information, the additional count field is simply determining that mongo is still logging...```\
-```Attempt to find errors in the mongod log and make sure the errors do not relate to shutdown events in the search head cluster. Since this does will ignore any events when either cluster shutsdown it might not be sensitive enough for some use cases...```\
+search = ```The main goal of this alert errors which might not appear in splunkd.log but are critical to keeping the kvstore running on the search heads. Please check the mongod.log file for further information, the additional count field is simply determining that mongo is still logging...\
+Attempt to find errors in the mongod log and make sure the errors do not relate to shutdown events in the search head cluster. Since this does will ignore any events when either cluster shutsdown it might not be sensitive enough for some use cases...```\
 index=_internal `searchheadhosts` `splunkadmins_mongo_source` (" E " OR " F " OR " W ") ```https://jira.mongodb.org/browse/SERVER-42078 advises this is harmless``` NOT "update of non-mod failed" `splunkadmins_mongodb_errors`\
 | regex _raw="^\s+?\S+\s+[EF]" \
 | search ```Exclude time periods where shutdowns were occurring``` AND NOT [`splunkadmins_shutdown_time(searchheadhosts,60,60)`]\
@@ -2851,8 +2851,8 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest `splunkindexerhostsvalue` /services/data/indexes/ \
 | search\
-    ```This search attempts to find indexes which are about to start rolling buckets to frozen due to disk space issues by checking how much percentage of the allocated cold section of disk is used. It does not take into account any volume sizing...```\
-    ```This is the more proactive form of IndexerLevel - Buckets are been frozen due to index sizing``` \
+    ```This search attempts to find indexes which are about to start rolling buckets to frozen due to disk space issues by checking how much percentage of the allocated cold section of disk is used. It does not take into account any volume sizing...\
+    This is the more proactive form of IndexerLevel - Buckets are been frozen due to index sizing``` \
 | join title splunk_server type=outer \
     [| rest `splunkindexerhostsvalue` /services/data/indexes-extended/] \
 | stats values(bucket_dirs.cold.bucket_size) AS currentColdSizeMB, values(bucket_dirs.home.warm_bucket_size) AS currentWarmSizeMB, max(bucket_dirs.home.event_max_time) AS latestTime, min(bucket_dirs.cold.event_min_time) AS earliestTime, min(bucket_dirs.home.event_min_time) AS earliestTimeHot, values(coldPath.maxDataSizeMB) AS coldPathSizeLimitMB, values(currentDBSizeMB) AS hotSizeMB, values(maxTotalDataSizeMB) AS maxTotalDataSizeMB, values(frozenTimePeriodInSecs) AS frozenTimePeriodInSecs, values(maxDataSize) AS maxDataSize, values(homePath.maxDataSizeMB) AS hotPathMaxDataSizeMB, values(bucket_dirs.home.warm_bucket_count) AS currentWarmCount, values(maxWarmDBCount) AS maxWarmDBCount by name, splunk_server \
@@ -2917,9 +2917,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Attempt to detect if an indexer crash resulted in corrupt buckets, if so alert the admin so they are aware...```\
-```The indexer is likely going to print the line \"WARN  IndexerService - Indexer was started dirty: splunkd startup may take longer than usual; searches may not be accurate until background fsck completes.\", however we also want to know if buckets were corrupted. In a clustered environment the corrupt buckets should be added to the cluster master fixup list and repaired online, if a non-clustered environment refer to the Splunk fsck documentation. Note that I'm unable to find a log message to advise when the OnlineFsck completes in splunkd.log. You may also wish to refer to alert IndexerLevel - Corrupt buckets via DBInspect```\
-```FYI fixup lines in the splunkd log file may look like \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds.\"```\
+search = ```Attempt to detect if an indexer crash resulted in corrupt buckets, if so alert the admin so they are aware...\
+The indexer is likely going to print the line "WARN  IndexerService - Indexer was started dirty: splunkd startup may take longer than usual; searches may not be accurate until background fsck completes.", however we also want to know if buckets were corrupted. In a clustered environment the corrupt buckets should be added to the cluster master fixup list and repaired online, if a non-clustered environment refer to the Splunk fsck documentation. Note that I'm unable to find a log message to advise when the OnlineFsck completes in splunkd.log. You may also wish to refer to alert IndexerLevel - Corrupt buckets via DBInspect\
+FYI fixup lines in the splunkd log file may look like "06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds.```\
 index=_internal sourcetype=splunkd `splunkadmins_splunkd_source` `indexerhosts` "At restart after an unclean shutdown found bucket path" OR ("finished moving hot to warm" caller=init_roll) OR (OnlineFsck "Scheduled repair fsck* kind='entire bucket'")\
 | rex field=path "(?P<pathWithoutHot>.*)(/|\\\\)\S+"\
 | join type=outer pathWithoutHot \
@@ -2959,8 +2959,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Find any LDAP groups that are reporting that they do not exist so can therefore be removed from the Splunk configuration```\
-```This appears to occur only after restarts of the Splunk server, however it is useful to know about as the authentication.conf can be cleaned up once found```\
+search = ```Find any LDAP groups that are reporting that they do not exist so can therefore be removed from the Splunk configuration\
+This appears to occur only after restarts of the Splunk server, however it is useful to know about as the authentication.conf can be cleaned up once found```\
 index=_internal sourcetype=splunkd `splunkenterprisehosts` `splunkadmins_splunkd_source` "was not found on the LDAP server"\
 | eval message=coalesce(message,event_message)\
 | stats max(_time) AS mostRecentlySeen, min(_time) AS firstSeen by message, host\
@@ -3083,8 +3083,8 @@ search = | rest "/servicesNS/-/-/configs/conf-macros?count=-1" `splunkadmins_res
 | rename eai:acl.app AS app\
 | fields title, app, definition, sharing\
 | eval splunk_server=`splunkadmins_splunk_server_name` \
-| search ```At this point you can add in remote search heads for macros by using the macro (with backticks) | append [ <backtick>AuditLogsMacroReport_Helper(\"<your remote host>\", \"remote_user\", \"remote_password\")<backtick> | splunk_server=... ]```\
-| search ```The lookup is going to use the first value it sees, so just dedup on app/title```\
+```At this point you can add in remote search heads for macros by using the macro (with backticks) | append [ <backtick>AuditLogsMacroReport_Helper("<your remote host>", "remote_user", "remote_password")<backtick> | splunk_server=... ]\
+The lookup is going to use the first value it sees, so just dedup on app/title```\
 | eval app=if(sharing=="global","global",'app')\
 | stats first(definition) AS definition, values(sharing) AS sharing by title, app, splunk_server\
 | outputlookup splunkadmins_macros
@@ -3306,7 +3306,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = ```Attempt to find entries in the splunkd logs that indiciate that Splunk is resource constrained and requires more CPU or similar```\
-index=_internal `indexerhosts`  sourcetype=splunkd `splunkadmins_splunkd_source` "Might indicate hardware or splunk limitations" OR "took longer than" ```This is useful for reporting but not so useful for alerting... OR \"WARN  PeriodicReapingTimeout\"``` NOT "Might indicate slow ldap server." ```Add in OR (WARN ConfMetrics) ?)``` \
+index=_internal `indexerhosts`  sourcetype=splunkd `splunkadmins_splunkd_source` "Might indicate hardware or splunk limitations" OR "took longer than" ```This is useful for reporting but not so useful for alerting... OR "WARN  PeriodicReapingTimeout"``` NOT "Might indicate slow ldap server." ```Add in OR (WARN ConfMetrics) ?)``` \
 | rex "^[\d-]+ [\d:\.]+( )+[\+-]?\d+( )+[^ ]+( )+(?P<componentAndArea>([^ ]+( )+){3}).*\((?P<number>\d+) milliseconds" \
 | rex "^[\d-]+ [\d:\.]+( )+[\+-]?\d+( )+[^ ]+( )+(?P<componentAndArea2>DispatchManager\s+([^ ]+( )+){3}).*elapsed_ms=(?P<number3>\d+)" \
 | rex "Spent (?P<number2>\d+)"\
@@ -3336,8 +3336,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```An attempt to detect excessive numbers of S2SFileReceiver / TcpInputProc failures on the indexing tier, these may indicate an issue. We are only looking for errors about replication data```\
-```An indexer peer that was constantly logging \"S2SFileReceiver...type=data_model already exists!\" / \"S2SFileReceiver...type=report_acceleration already exists!\" has been fixed by restart (once so far)```\
+search = ```An attempt to detect excessive numbers of S2SFileReceiver / TcpInputProc failures on the indexing tier, these may indicate an issue. We are only looking for errors about replication data\
+An indexer peer that was constantly logging \"S2SFileReceiver...type=data_model already exists!\" / \"S2SFileReceiver...type=report_acceleration already exists!\" has been fixed by restart (once so far)```\
 index=_internal sourcetype=splunkd `indexerhosts` sourcetype=splunkd `splunkadmins_splunkd_source` ("ERROR TcpInputProc" "event=replicationData") OR ("ERROR S2SFileReceiver" "error alerting slave about") OR ("ERROR S2SFileReceiver" "error adding new summary replica to slave")\
 | rex "(?P<error>ERROR [^-]+- [^=]+=)(?P<postEquals>[^ ]+) (?P<postEquals2>[^=]+=[^ ]+)"\
 | rex field=err "(?P<type>type=.*)"\
@@ -3374,9 +3374,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins 
 request.ui_dispatch_view = search
-search = ```Attempt to detect when a Splunk scripted_input appears to be running at OS level even though disabled=1 is set```\
-```Splunk support have advised that the modular input scripts run by design, in fact disabled=1 means the inheriting input stanzas should be disabled, not that the modular input is disabled```\
-```As per the updated documentation on https://docs.splunk.com/Documentation/AddOns/released/Overview/Distributedinstall best practice is now to remove the inputs.conf and inputs.conf.spec on SH clusters...```\
+search = ```Attempt to detect when a Splunk scripted_input appears to be running at OS level even though disabled=1 is set\
+Splunk support have advised that the modular input scripts run by design, in fact disabled=1 means the inheriting input stanzas should be disabled, not that the modular input is disabled\
+As per the updated documentation on https://docs.splunk.com/Documentation/AddOns/released/Overview/Distributedinstall best practice is now to remove the inputs.conf and inputs.conf.spec on SH clusters...```\
 index=_introspection `localsearchheadhosts` sourcetype=splunk_resource_usage \
 | spath component \
 | search component=PerProcess data.process!=splunkd \
@@ -3404,8 +3404,8 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Detect forwarders stuck connecting to a single indexer or heavy forwarder for an extended period of time...Assuming more than 60 seconds of continuous traffic is a problem...this may need to be customised for your environment```\
-```Note that the number of metrics defaults to the top 10 measured every 30 seconds, so if this is customised you will need to change this alert```\
+search = ```Detect forwarders stuck connecting to a single indexer or heavy forwarder for an extended period of time...Assuming more than 60 seconds of continuous traffic is a problem...this may need to be customised for your environment\
+Note that the number of metrics defaults to the top 10 measured every 30 seconds, so if this is customised you will need to change this alert```\
 index=_internal sourcetype=splunkd `splunkadmins_metrics_source` sourcetype=splunkd group=tcpin_connections Metrics `indexerhosts` OR `heavyforwarderhosts`\
 | eval ingest_pipe = if(isnotnull(ingest_pipe), ingest_pipe, "none")\
 | streamstats time_window=60s count by hostname, host, ingest_pipe\
@@ -3425,8 +3425,8 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Detect forwarders stuck connecting to a single indexer or heavy forwarder for an extended period of time...Assuming more than 60 seconds of continuous traffic is a problem...this may need to be customised for your environment```\
-```Note that the number of metrics defaults to the top 10 measured every 30 seconds, so if this is customised you will need to change this alert```\
+search = ```Detect forwarders stuck connecting to a single indexer or heavy forwarder for an extended period of time...Assuming more than 60 seconds of continuous traffic is a problem...this may need to be customised for your environment\
+Note that the number of metrics defaults to the top 10 measured every 30 seconds, so if this is customised you will need to change this alert```\
 index=_internal sourcetype=splunkd `splunkadmins_metrics_source` sourcetype=splunkd group=tcpin_connections Metrics `indexerhosts` OR `heavyforwarderhosts`\
 | eval ingest_pipe = if(isnotnull(ingest_pipe), ingest_pipe, "none")\
 | streamstats time_window=60s count by name, host, ingest_pipe\
@@ -3467,8 +3467,8 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```For the alert version of this report refer to IndexerLevel - Unclean Shutdown - Fsck, you may also wish to try IndexerLevel - Corrupt buckets via DBInspect```\
-```Attempt to find bucket corruption errors in the splunkd logs. this can also be found at search head level via the info.csv (not indexed by default). In a clustered environment a message such as \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds\" may appear once the auto-repair has occurred. Finally it may appear if log_search_messages is set in limits.conf (enabled by default in 9.1 and above), the sourcetype will be splunk_search_messages```\
+search = ```For the alert version of this report refer to IndexerLevel - Unclean Shutdown - Fsck, you may also wish to try "IndexerLevel - Corrupt buckets via DBInspect"\
+Attempt to find bucket corruption errors in the splunkd logs. this can also be found at search head level via the info.csv (not indexed by default). In a clustered environment a message such as \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds\" may appear once the auto-repair has occurred. Finally it may appear if log_search_messages is set in limits.conf (enabled by default in 9.1 and above), the sourcetype will be splunk_search_messages```\
 index=_internal `indexerhosts` sourcetype=splunkd `splunkadmins_splunkd_source` IndexerService OR HotBucketRoller "corrupt" newly ```newly appears to show corruption, previously may be the term for when it is fixed...```\
 | stats values(Bucket) AS bucketList by idx \
 | eval bucketCount=mvcount(bucketList)\
@@ -3494,9 +3494,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Further testing required. Detect failures from the search.log advising that the peer was unable to send a response, for example This can be caused by the peer unexpectedly closing or resetting the connection. Search results might be incomplete!...This requires the search.log messages (see description of this alert) to obtain the splunk_search_messages sourcetype. The Unable to distribute to peer named status=Down scenario can also result from having many indexers and may require an increase to the timeouts in distsearch.conf```\
-```info.csv often reports failures as well but sometimes these are not in search.log and vice-versa. Unable to distribute to peer/Connection failed/Unable to determine response all appear to be some kind of failure. Attempting to use the [search] log_search_messages = true in the limits.conf file and then use the search_messages.log file to find what would normally appear in info.csv in the dispatch directory per-search...Note this is enabled by default in 9.1 and above```\
-index=_internal sourcetype=splunk_server_messages source!="*rsa_scheduler_*" `searchheadhosts` ("error" "for peer") OR "Error connecting" OR "Got status" ```Ignoring \"HTTP error status message from\" OR \"HTTP client error\" as they tend to appear when one of the previous examples is there...```\
+search = ```Further testing required. Detect failures from the search.log advising that the peer was unable to send a response, for example This can be caused by the peer unexpectedly closing or resetting the connection. Search results might be incomplete!...This requires the search.log messages (see description of this alert) to obtain the splunk_search_messages sourcetype. The Unable to distribute to peer named status=Down scenario can also result from having many indexers and may require an increase to the timeouts in distsearch.conf\
+info.csv often reports failures as well but sometimes these are not in search.log and vice-versa. Unable to distribute to peer/Connection failed/Unable to determine response all appear to be some kind of failure. Attempting to use the [search] log_search_messages = true in the limits.conf file and then use the search_messages.log file to find what would normally appear in info.csv in the dispatch directory per-search...Note this is enabled by default in 9.1 and above```\
+index=_internal sourcetype=splunk_server_messages source!="*rsa_scheduler_*" `searchheadhosts` ("error" "for peer") OR "Error connecting" OR "Got status" ```Ignoring "HTTP error status message from" OR "HTTP client error" as they tend to appear when one of the previous examples is there...```\
 | rex "for peer (?P<peer>[^\.]+)"\
 | rex "ERROR\s+\S+\s+-\s+(sid:[^ ]+)?(?P<message>.*)"\
 | bin _time span=1m\
@@ -3534,9 +3534,9 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Note this requires further testing due to switch to splunk_search_messages```\
-```Attempt to find corrupt buckets appearing in the search heads dispatch/info.csv files, this will show that a user is seeing the \"data may be corrupt\" messages```\
-```In a clustered environment this should auto-repair via the cluster master fixup list, messages such as \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds.\" should appear in the splunkd logs. In a non-clustered environment refer to the Splunk fsck documentation. You may also wish to try IndexerLevel - Corrupt buckets via DBInspect```\
+search = ```Note this requires further testing due to switch to splunk_search_messages\
+Attempt to find corrupt buckets appearing in the search heads dispatch/info.csv files, this will show that a user is seeing the "data may be corrupt" messages\
+In a clustered environment this should auto-repair via the cluster master fixup list, messages such as \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds.\" should appear in the splunkd logs. In a non-clustered environment refer to the Splunk fsck documentation. You may also wish to try IndexerLevel - Corrupt buckets via DBInspect```\
 index=_internal sourcetype=splunk_search_messages "corrupt" OR "corrupted" OR "Consider running fsck" `searchheadhosts` \
 | rex ",\"(\[[^\]]+\]\[[^\]]+\]: )?\[(?P<peer>[^\]]+)"\
 | rex "message=\[(?P<peer>[^\]]+)" \
@@ -3563,9 +3563,9 @@ display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 schedule_window = 30
-search = ```The listed users have reached the maximum disk quota, they may be unaware so it is best to let them know about this issue...```\
-```Note that the REST API call accesses the jobs list which can expire for ad-hoc jobs in 10 minutes, the introspection index has data for a longer period of time however it's not as accurate as the rest version. This alert also outputs the emailed users to a lookup so they don't continue to receive this same email without some kind of throttle per-user```\
-```The REST version is called SearchHeadLevel - Users exceeding the disk quota and is search head specific```\
+search = ```The listed users have reached the maximum disk quota, they may be unaware so it is best to let them know about this issue...\
+Note that the REST API call accesses the jobs list which can expire for ad-hoc jobs in 10 minutes, the introspection index has data for a longer period of time however it's not as accurate as the rest version. This alert also outputs the emailed users to a lookup so they don't continue to receive this same email without some kind of throttle per-user\
+The REST version is called "SearchHeadLevel - Users exceeding the disk quota" and is search head specific```\
 index=_internal sourcetype=splunkd `splunkenterprisehosts` (`splunkadmins_splunkd_source`) "maximum disk usage quota" `splunkadmins_users_exceeding_diskquota` NOT [| inputlookup splunkusersexceedingdiskquota.csv | fields username ]\
 | stats max(_time) AS mostRecent by username, reason, host\
 | rename username AS username_from_search\
@@ -3585,11 +3585,11 @@ index=_internal sourcetype=splunkd `splunkenterprisehosts` (`splunkadmins_splunk
         | rename data.search_props.app AS app, data.search_props.provenance AS dashboardURLorSearchName, data.search_props.type AS type\
         | sort - MBwritten\
         | eval approxDuration=substr(tostring(approxDuration,"duration"),0,8)\
-        | appendcols\
-            [ search ```At this point you need to either lookup the username to email translation, here's an example using ldapsearch: ldapsearch search=\"(&(CN=$username_from_search$)(objectClass=organizationalPerson))\" attrs=mail | fields mail``` ]\
+        ```| appendcols\
+            [  At this point you need to either lookup the username to email translation, here's an example using ldapsearch: ldapsearch search=\"(&(CN=$username_from_search$)(objectClass=organizationalPerson))" attrs=mail | fields mail ] ```\
         | eval email_to=mail\
         | fields - mail\
-        | search ```'Remove search/comment and replace <EQ> with equals to use sendresults to make this fully automated. AppInspect badge does not allow dependencies. sendresults subject<EQ>"Splunk Disk Quota Exceeded" body<EQ>$body$ msgstyle<EQ>"table {font-family:Arial;font-size:12px;border: 1px solid black;padding:3px}th {background-color:#AAAAAA;color:#fff;border-left: solid 1px #e9e9e9} td {border:solid 1px #e9e9e9}" showemail<EQ>f'```\
+        ```Remove search/comment and replace <EQ> with equals to use sendresults to make this fully automated. AppInspect badge does not allow dependencies. sendresults subject="Splunk Disk Quota Exceeded" body=$body$ msgstyle="table {font-family:Arial;font-size:12px;border: 1px solid black;padding:3px}th {background-color:#AAAAAA;color:#fff;border-left: solid 1px #e9e9e9} td {border:solid 1px #e9e9e9}" showemail=f```\
         | head 20 ] maxsearches=30\
         ]\
 | where username_from_search!="workaround for map errors"\
@@ -3678,8 +3678,8 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = ```May not be 100% accurate, still under testing. deleteBucket frozen=false is usually excess bucket removal```\
 index=_internal "Creating hot bucket" OR ((CMSlave deleteBucket) AND "frozen=false") OR "freeze succeeded" sourcetype=splunkd `splunkadmins_splunkd_source` `indexerhosts`\
-```Multiplying by replication factor as each hot bucket is duplicated```\
-```To split by index\
+```Multiplying by replication factor as each hot bucket is duplicated\
+To split by index\
 | rex "(/[^/]+){2}/(?P<idx2>[^/]+)"\
 | eval idx=if(isnull(idx),idx2,idx)\
 ```\
@@ -3713,8 +3713,8 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = Global
 request.ui_dispatch_view = search
-search = ```Find searches which have been auto-finalized and the search contents which was running when the search was auto-finalized. Very similar to Users Exceeding the disk quota however this covers both disk quota and srchMaxTime. Note this alert requires further testing```\
-```This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1```\
+search = ```Find searches which have been auto-finalized and the search contents which was running when the search was auto-finalized. Very similar to Users Exceeding the disk quota however this covers both disk quota and srchMaxTime. Note this alert requires further testing\
+This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1```\
 index=_internal `searchheadhosts` sourcetype=splunk_search_messages auto-finalized\
  ```for even more info...OR canceled OR auto-canceled OR cancelled``` \
 | rex field=source "[/\\\]dispatch[/\\\](?P<sid>[^/\\\]+)"\
@@ -4059,8 +4059,8 @@ display.visualizations.charting.chart = area
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```This likely came from a Splunk conf presentation but I cannot remember which one so cannot attribute the original author!```\
-```Determine the length of time a scheduled search takes to run compared to how often it is configured to run, excluding acceleration jobs```\
+search = ```This likely came from a Splunk conf presentation but I cannot remember which one so cannot attribute the original author!\
+Determine the length of time a scheduled search takes to run compared to how often it is configured to run, excluding acceleration jobs```\
 index=_internal `searchheadhosts` sourcetype=scheduler source=*scheduler.log (user=*) savedsearch_name!="_ACCELERATE_DM*"\
 | stats avg(run_time) as average_runtime_in_sec count(savedsearch_name) as num_times_per_week sum(run_time) as total_runtime_sec by savedsearch_name user app host\
 | eval ran_every_x_mins=round(60/(num_times_per_week/168))\
@@ -4192,7 +4192,7 @@ index=_internal sourcetype=splunkd_access OR sourcetype=splunkd_ui_access method
 | where type!="unknown"\
 | eval app=if(isnull(app),"*",app)\
 | eval type2 = if(type=="eventtypes","tags",null())\
-| search ```note that eventtypes can have tags created so assume eventtype == tag creation, eventtypes_conf doesn't appear to work```\
+```note that eventtypes can have tags created so assume eventtype == tag creation, eventtypes_conf doesn't appear to work```\
 | stats values(_time) AS times, values(user) AS userList, values(type2) AS type2 by type, app
 
 [SearchHeadLevel - Detect changes to knowledge objects directory]
@@ -4373,15 +4373,15 @@ index=_audit info=granted "search='" NOT "savedsearch_name=\"Threat - Correlatio
 | makemv userList\
 | eval userCount = mvcount(userList)\
 | mvexpand userList\
-| search ```Beyond this point this search will likely need customisation to work in a particular environment, remove the comments and \ symbols to make this work...\
-| ldapfilter search=\"(&(CN=$userList$)(objectClass=organizationalPerson))\" attrs=\"mail\"\
+| search ```Beyond this point this search will likely need customisation to work in a particular environment...\
+| ldapfilter search="(&(CN=$userList$)(objectClass=organizationalPerson))" attrs="mail"\
 | where isnotnull(mail)\
 ```\
 | stats values(provenance) AS searchInfo, values(searchDuration) AS searchDuration, values(loadCount) AS loadCount, values(mail) AS email_to, max(userCount) AS maxUsersPerDashboard by app\
 | nomv email_to\
 | rex mode=sed field=email_to "s/ /;/g"\
 | search ```\
-| sendresults subject=\"Shared dashboards not using saved searches\" msgstyle=\"table {font-family:Arial;font-size:12px;border: 1px solid black;padding:3px}th {background-color:#AAAAAA;color:#fff;border-left: solid 1px #e9e9e9} td {border:solid 1px #e9e9e9}\" showemail=f showsubj=f\
+| sendresults subject="Shared dashboards not using saved searches" msgstyle="table {font-family:Arial;font-size:12px;border: 1px solid black;padding:3px}th {background-color:#AAAAAA;color:#fff;border-left: solid 1px #e9e9e9} td {border:solid 1px #e9e9e9}" showemail=f showsubj=f\
 | fields app, searchInfo\
 | eval currtime=now()\
 | outputlookup dashboard_automated_app_history.csv append=true\
@@ -4453,8 +4453,8 @@ display.visualizations.show = 0
 description = Report only? Yes. Attempt to query the indexing tier to determine how often they are receiving new knowledge bundles from the various search tiers. From here calculate the time period between uploads, how long it takes and how many bundles during the time period
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Query the indexing tier to determine how often they are receiving new knowledge bundles from the various search tiers. From here calculate the time period between uploads, how long it takes and how many bundles during the time period```\
-    ```Alternatives would be to check the bundle uploads via: 'index=_internal sourcetype=splunkd source=*metrics.log* group=bundles_uploads' or the bundle downloads with group=bundles_downloads, in particular the baseline_count/delta_count appear to show the different methods used but it appears to be more accurate to check the splunkd access logs on the indexing tier itself in 7.0.x. In 8.0.x the cascading bundle adds various complications, if no cascading bundle is in use you can drop the appends completely```\
+search = ```Query the indexing tier to determine how often they are receiving new knowledge bundles from the various search tiers. From here calculate the time period between uploads, how long it takes and how many bundles during the time period\
+    Alternatives would be to check the bundle uploads via: 'index=_internal sourcetype=splunkd source=*metrics.log* group=bundles_uploads' or the bundle downloads with group=bundles_downloads, in particular the baseline_count/delta_count appear to show the different methods used but it appears to be more accurate to check the splunkd access logs on the indexing tier itself in 7.0.x. In 8.0.x the cascading bundle adds various complications, if no cascading bundle is in use you can drop the appends completely```\
     index=_internal `indexerhosts` sourcetype=splunkd_access source=*splunkd_access.log (/services/receivers/bundle OR /services/replication/cascading/upload/payload) method=POST \
 | rex field=uri "/services/receivers/(?P<type>[^/]+)/(?P<guid>[^/]+)" \
 | rex field=uri "/cascading/upload/payload/(?P<planid>[^/]+)$" \
@@ -4612,7 +4612,7 @@ search = | rest /services/authorization/roles splunk_server="local" \
 | stats values(srchIndexesAllowed) AS srchIndexesAllowed, values(index) AS srchIndexesDefault by roles, splunk_server \
 | makemv srchIndexesAllowed tokenizer=(\S+) \
 | eval srchIndexesDefault = if(srchIndexesDefault=="requiredformvexpand",null(),srchIndexesDefault)\
-| search ```You can add this in if you have mutiple search head clusters or search heads after removing the backspaces...| append [ savedsearch \"SearchHeadLevel - IndexesPerRole Remote Report\" url=\"...\" user=\"...\" pass=\"...\" | eval splunk_server="..." ]```\
+```You can add this in if you have mutiple search head clusters or search heads ...| append [ savedsearch "SearchHeadLevel - IndexesPerRole Remote Report" url="..." user="..." pass="..." | eval splunk_server="..." ]```\
 | outputlookup splunkadmins_indexes_per_role
 
 [SearchHeadLevel - Search Queries summary exact match]
@@ -4626,8 +4626,8 @@ display.general.type = statistics
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | multisearch \
-    [ search ```Last modified 2022-02-14 Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. The multisearch is only required if you want to capture sub-searches from join, append or similar, these require a bit more work so that's why the multisearch is there, in fact anything containing one of those keywords is dealt with in the second search, not this one...``` \
-    ```Note that the regexes need more work, for now, limits.conf [rex] match_limit = 1000000 is my workaround (main issue is the union/set/multisearch rex)``` \
+    [ search ```Last modified 2022-02-14 Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. The multisearch is only required if you want to capture sub-searches from join, append or similar, these require a bit more work so that's why the multisearch is there, in fact anything containing one of those keywords is dealt with in the second search, not this one... \
+    Note that the regexes need more work, for now, limits.conf [rex] match_limit = 1000000 is my workaround (main issue is the union/set/multisearch rex)``` \
         index=_audit "info=completed" search_id!="'SummaryDirector_*" search_id!="'rsa_*" search_id!="'RemoteStorageRetrieveBuckets_*" search_id!="'ta_*" search_id!="'RemoteStorageRetrieveIndexes*" scan_count>0 \
     | rex "(?s), search='(?P<search>.*)\]$" \
     | search ```Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"``` \
@@ -4733,8 +4733,8 @@ display.page.search.tab = statistics
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | multisearch \
-    [ search ```Last modified 2022-02-14 Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. The multisearch is only required if you want to capture sub-searches from join, append or similar, these require a bit more work so that's why the multisearch is there, in fact anything containing one of those keywords is dealt with in the second search, not this one...``` \
-    ```Note that the regexes need more work, for now, limits.conf [rex] match_limit = 1000000 is my workaround (main issue is the union/set/multisearch rex)``` \
+    [ search ```Last modified 2022-02-14 Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. The multisearch is only required if you want to capture sub-searches from join, append or similar, these require a bit more work so that's why the multisearch is there, in fact anything containing one of those keywords is dealt with in the second search, not this one... \
+    Note that the regexes need more work, for now, limits.conf [rex] match_limit = 1000000 is my workaround (main issue is the union/set/multisearch rex)``` \
         index=_audit "info=completed" search_id!="'SummaryDirector_*" search_id!="'rsa_*" search_id!="'RemoteStorageRetrieveBuckets_*" search_id!="'ta_*" search_id!="'RemoteStorageRetrieveIndexes*" scan_count>0 \
     | rex "(?s), search='(?P<search>.*)\]$" \
     | search ```Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"``` \
@@ -4816,8 +4816,8 @@ search = | multisearch \
 | search ```We now deal with cases where search earliest/latest times were not specified, assume all time is about 1 year in the past and latest time was the search run time``` \
 | eval search_lt=if(search_lt=="N/A",_time,search_lt), search_et=if(search_et=="N/A",now()-(365*24*60*60),search_et) \
 | eval period=search_lt-search_et \
-| search ```Now that we have a giant list of indexes, we want to strip any quote characters and lowercase them in case we use a kvstore for lookups or similar.``` \
-| search ```Run a lookup to find the default indexes and the allowed indexes per user``` \
+```Now that we have a giant list of indexes, we want to strip any quote characters and lowercase them in case we use a kvstore for lookups or similar. \
+Run a lookup to find the default indexes and the allowed indexes per user``` \
 | eval roles=replace(roles,"'","") \
 | makemv roles delim="+" \
 | lookup splunkadmins_indexes_per_role roles, splunk_server \
@@ -4835,7 +4835,7 @@ search = | multisearch \
 | eval multi=if(mvcount(indexes)>1,"true","false") \
 | stats values(_time) AS _time, values(total_run_time) AS total_run_time, values(event_count) AS event_count, values(scan_count) AS scan_count, values(search_et) AS search_et, values(search_lt) AS search_lt, values(savedsearch_name) AS savedsearch_name, values(multi) AS multi, max(duration_command_search_index) AS duration_index, max(duration_command_search_rawdata) AS duration_rawdata, max(invocations_command_search_index_bucketcache_hit) AS cache_index_hits, max(invocations_command_search_index_bucketcache_miss) AS cache_index_miss, max(duration_command_search_index_bucketcache_hit) AS cache_index_hit_duration, max(duration_command_search_index_bucketcache_miss) AS cache_index_miss_duration, max(invocations_command_search_rawdata_bucketcache_hit) AS cache_rawdata_hits, max(invocations_command_search_rawdata_bucketcache_miss) AS cache_rawdata_miss, max(duration_command_search_rawdata_bucketcache_hit) AS cache_rawdata_hit_duration, max(duration_command_search_rawdata_bucketcache_miss) AS cache_rawdata_miss_duration, values(provenance) AS provenance by user, type, search_id, indexes, search_head_cluster, app_name, short \
 | eval period=search_lt-search_et \
-| search ```Commands like multikv result in giant event count numbers compared to scan count, lower the lispy back down to normal to prevent the stats from been broken. lispy efficiency as per Martin Muller's conf presentations``` \
+```Commands like multikv result in giant event count numbers compared to scan count, lower the lispy back down to normal to prevent the stats from been broken. lispy efficiency as per Martin Muller's conf presentations``` \
 | eval lispy_efficiency = if(event_count>scan_count,scan_count,event_count) / scan_count
 
 [SearchHeadLevel - Search Queries summary exact match by user]
@@ -4849,7 +4849,7 @@ display.general.type = statistics
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | savedsearch "SearchHeadLevel - Search Queries summary exact match"\
-| search ```TODO breakdown the counts into time periods, perhaps 1hour, 4 hours, 8 hours, 24 hours, 3 days, 7 days, 14 days, 21 days, 30 days, 2 months, 3 months, 6months, > 60 months? or similar. Do a count for each one as that would be useful for a dashboard...``` \
+```TODO breakdown the counts into time periods, perhaps 1hour, 4 hours, 8 hours, 24 hours, 3 days, 7 days, 14 days, 21 days, 30 days, 2 months, 3 months, 6months, > 60 months? or similar. Do a count for each one as that would be useful for a dashboard...``` \
 | stats count, dc(indexes) AS indexes, max(period) AS maxPeriod, avg(period) AS avgPeriod, median(period) AS medianPeriod, \
     avg(total_run_time) AS avg_total_run_time, max(total_run_time) AS max_total_run_time, median(total_run_time) AS median_total_run_time, avg(lispy_efficiency) AS avg_lispy_efficiency, max(lispy_efficiency) AS max_lispy_efficiency, min(lispy_efficiency) AS min_lispy_efficiency, median(lispy_efficiency) AS median_lispy_efficiency by user\
 | fillnull max_lispy_efficiency, min_lispy_efficiency, median_lispy_efficiency \
@@ -4869,7 +4869,7 @@ search = | savedsearch "SearchHeadLevel - Search Queries summary exact match"\
 | eval period=case(period<900,"a<=15 minutes",period<3600,"b<=1hour",period<=14400,"c<=4hours",period<=86400,"d<=24hours",period<=604800,"e<=7days",period<=1209600,"f<=14days",period<=2592000,"g<=30days",period<=5184000,"h<=60days",period<=7776000,"i<=90days",period<=15552000,"j<=180days",period>15552000,"k>180days")\
 | stats count by indexes, period\
 | rename indexes AS index\
-| search ```Temporary hack to make this visualize without errors below...```\
+```Temporary hack to make this visualize without errors below...```\
 | eval indexfirstletter=substr(index,0,1)\
 | stats sum(count) AS count by indexfirstletter, period\
 | xyseries period indexfirstletter count
@@ -5630,7 +5630,7 @@ search = | rest /servicesNS/-/-/data/ui/views `splunkadmins_restmacro` \
 | eval viztokens=replace(viztokens,"\$","\\$")\
 | makemv tokenizer=(\S+) viztokens\
 | eval viztokens=split(viztokens,",") \
-| search ```This would be more accurate as such but make the search really, really slow...so combining into 1 large value...\
+```This would be more accurate as such but make the search really, really slow...so combining into 1 large value...\
 | streamfilter fieldname=rowtoken_matches pattern=rowtokens rowsearch\
 | streamfilter fieldname=paneltoken_matches pattern=paneltokens panelsearch\
 | streamfilter fieldname=chartoken_matches pattern=charttokens chartsearch\
@@ -5774,7 +5774,7 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = ```A retrospective alert to advise that the Splunk process was terminated and this likely requires further investigation``` \
 index=_internal index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) \
-```Expecting 'FATAL ProcessRunner - Unexpected EOF from process runner child!' OR 'ProcessRunner - helper process seems to have died (child killed by signal 9: Killed)!' which can occur by the OOM killer for example``` \
+```Expecting "FATAL ProcessRunner - Unexpected EOF from process runner child!" OR "ProcessRunner - helper process seems to have died (child killed by signal 9: Killed)!" which can occur by the OOM killer for example``` \
 "Unexpected EOF from process runner" OR "helper process seems to have died" \
 | eval event_message=coalesce(event_message,message) \
 | stats count, earliest(_time) AS firstSeen, latest(_time) AS lastSeen, values(event_message) AS event_message by host\
@@ -6107,8 +6107,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Look for dispatch problems in the splunk_search_messages sourcetype``` \
-```This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1```\
+search = ```Look for dispatch problems in the splunk_search_messages sourcetype \
+This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1```\
 index=_internal `searchheadhosts` orig_component="DispatchThread" sourcetype=splunk_search_messages \
 | cluster t=0.4 showcount=true \
 | table _time, cluster_count, _raw \
@@ -6376,8 +6376,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Attempt to find various messages in the splunk_search_messages which are related to scheduled searches or dashboards which may require correcting, ignore ad-hoc searches```\
-```This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1```\
+search = ```Attempt to find various messages in the splunk_search_messages which are related to scheduled searches or dashboards which may require correcting, ignore ad-hoc searches\
+This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1```\
         index=_internal `searchheadhosts` sourcetype=splunk_search_messages "MultiValueProcessor" OR "SearchStatusEnforcer" OR "SearchOperator" OR "SQL" OR "truncated" OR "script" OR "KV" OR "External" OR "outputcsv" OR "reset" OR "match_limit" OR authorized OR terminated OR depth_limit OR driver OR dbx OR command OR java OR reading OR training OR DensityFunction OR (TERM(in-memory) limit) OR terminated OR invalid OR (missing NOT orig_component="SummaryIndexProcessor") OR Unable OR reset OR AutoLookupDriver OR ImportError OR jdbc OR SSLError OR TERM(code=) OR REST OR SearchParser \
 OR (missing NOT orig_component="SummaryIndexProcessor") OR Unable OR ("Can't" "parse") OR "field(s) do not exist" OR ("setting" "deprecated") OR ("ignored" "missing") OR "Dropping field(s) with too many distinct values" OR "does not exist" OR orig_component="TsidxStats" OR orig_component="SearchOrchestrator" OR orig_component="ForeachProcessor" OR orig_component="SearchPhaseGenerator" OR orig_component="SearchProcessor" OR HTTPError\
 ```Potential issues that are not included SearchEvaluatorBasedExpander, shows if eventtypes/tags are disabled/do not exist or similar``` `splunkadmins_searchmessages_user_1` \
@@ -6426,8 +6426,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```Attempt to find various messages in the splunk_search_messages which are related to scheduled searches or dashboards which may require correcting, ignore ad-hoc searches```\
-```This does require the limits.conf log_search_messages=true setting to be enabled to work. If below version 9.1```\
+search = ```Attempt to find various messages in the splunk_search_messages which are related to scheduled searches or dashboards which may require correcting, ignore ad-hoc searches\
+This does require the limits.conf log_search_messages=true setting to be enabled to work. If below version 9.1```\
     index=_internal `searchheadhosts` sourcetype=splunk_search_messages (Unable peer) OR bundles OR "bundle replication" OR corrupt OR connecting OR ReadWrite OR Socket OR Timed OR incomplete OR cleanly OR Timeout OR Timed OR process OR insufficient OR (bucket failed) OR "occur when processing chunks in running lookup command" OR "because KV Store status is currently unknown" OR (File line) OR (SearchPipelineExecutor NOT "exceeded configured match_limit") OR S2BucketCache OR DistributedSearchResultCollectionManager OR ("Field extractor" "unusually slow") OR "line *:" OR GeoIPProvider OR "restricting search to" OR ExternalProvider NOT "Unable to find tag" NOT "Unable to parse the search" NOT ("Eventtype" "does not exist") NOT "Error in 'outputlookup' command: You have insufficient privileges" NOT "insufficient data in ITSI summary index for policies" \
 NOT ("Failed to fetch REST endpoint" "/services/data/indexes-extended" "Check that the URI path provided exists in the REST API" OR "Not Found")\
 `splunkadmins_searchmessages_admin_1`\
@@ -7677,8 +7677,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = ```The indexer is freezing buckets due to disk space pressure before the frozenTimePeriodInSecs limit has been reached, this could be a problem if it is not expected...```\
-```_introspection defaults to size based so exclude it``` \
+search = ```The indexer is freezing buckets due to disk space pressure before the frozenTimePeriodInSecs limit has been reached, this could be a problem if it is not expected...\
+_introspection defaults to size based so exclude it``` \
 index=_internal `cluster_masters` sourcetype=splunkd (`splunkadmins_splunkd_source`) freezing reason NOT "exceeded frozenTimePeriodInSecs" \
 `splunkadmins_bucketfrozen`\
 | eval newestDataInBucket=strftime(bucket_latest , "%+"), oldestDataInBucket = strftime(bucket_earliest, "%+") \
@@ -7759,7 +7759,7 @@ search = index=_internal `sysloghosts` statistics\
 [ eval <<FIELD>>diff='<<FIELD>>'-'prev_<<FIELD>>' ]\
 | fields - processed_center_received_diff\
 | timechart avg(*_diff) AS "*_diff" span=10m by host\
-| search ```At this point you probably want to do a | fields *d_syslog_output* or similar```
+```At this point you probably want to do a | fields *d_syslog_output* or similar```
 
 [SearchHeadLevel - Knowledge Bundle contents]
 action.email.useNSSubject = 1
@@ -8511,7 +8511,7 @@ request.ui_dispatch_view = search
 search = index=_introspection sourcetype=search_telemetry `searchheadhosts` `splunkadmins_events_per_second`\
 | table _time, perf.scan_count, phases.phase_0.elapsed_time_aggregations.avg, perf.search_runtime_secs, desc.savedsearch_name\
 | rename perf.scan_count AS scan_count, phases.phase_0.elapsed_time_aggregations.avg AS indexer_avg, perf.search_runtime_secs AS search_runtime, desc.savedsearch_name AS savedsearch_name\
-``` note that if scan_count exceeds 500K the stats disappear in 9.0.3/9.1.2, which is frustrating. Ad-hoc searches do not have this issue ```\
+``` note that if scan_count exceeds 500K the stats disappear in 9.0.3/9.1.2/9.2.2, which is frustrating. Ad-hoc searches do not have this issue ```\
 | eval events_per_second=round(scan_count/indexer_avg,2)\
 | eval indexer_avg=round(indexer_avg,2), search_runtime=round(search_runtime,2)\
 | fillnull indexer_avg events_per_second

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -2235,9 +2235,9 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = ```sendmodalert or sendalert errors and warnings may be an issue relating to the creation of alerts via a script```\
 index=_internal `splunkenterprisehosts` ("ERROR sendmodalert" action) OR ("WARN sendmodalert" action) OR "Error in 'sendalert' command" sourcetype=splunkd (`splunkadmins_splunkd_source`)\
-`comment("If you need more context on the above errors add this snippet into the above search (remove the \\):\
+```If you need more context on the above errors add this snippet into the above search (remove the \\):\
 OR \"sendmodalert - Invoking modular alert action\"\
-")`\
+```\
 `splunkadmins_sendmodalert_errors`\
 | rex field=results_file "[/\\\]dispatch[/\\\](?P<sid>[^/]+)"\
 | eval sid=if(isnull(sid),"NOMATCH",sid)\
@@ -3679,10 +3679,10 @@ request.ui_dispatch_view = search
 search = ```May not be 100% accurate, still under testing. deleteBucket frozen=false is usually excess bucket removal```\
 index=_internal "Creating hot bucket" OR ((CMSlave deleteBucket) AND "frozen=false") OR "freeze succeeded" sourcetype=splunkd `splunkadmins_splunkd_source` `indexerhosts`\
 ```Multiplying by replication factor as each hot bucket is duplicated```\
-`comment("To split by index\
+```To split by index\
 | rex "(/[^/]+){2}/(?P<idx2>[^/]+)"\
 | eval idx=if(isnull(idx),idx2,idx)\
-")`\
+```\
 | timechart span=1d count(eval(searchmatch("Creating hot bucket"))) AS created, count(eval(searchmatch("((CMSlave deleteBucket) AND \"frozen=false\") OR \"freeze succeeded\""))) AS frozenCount\
 | eval change=(created*`splunkadmins_replicationfactor`)-frozenCount\
 | fields - created, frozenCount
@@ -4373,19 +4373,19 @@ index=_audit info=granted "search='" NOT "savedsearch_name=\"Threat - Correlatio
 | makemv userList\
 | eval userCount = mvcount(userList)\
 | mvexpand userList\
-| search `comment("Beyond this point this search will likely need customisation to work in a particular environment, remove the comments and \ symbols to make this work...\
+| search ```Beyond this point this search will likely need customisation to work in a particular environment, remove the comments and \ symbols to make this work...\
 | ldapfilter search=\"(&(CN=$userList$)(objectClass=organizationalPerson))\" attrs=\"mail\"\
 | where isnotnull(mail)\
-")`\
+```\
 | stats values(provenance) AS searchInfo, values(searchDuration) AS searchDuration, values(loadCount) AS loadCount, values(mail) AS email_to, max(userCount) AS maxUsersPerDashboard by app\
 | nomv email_to\
 | rex mode=sed field=email_to "s/ /;/g"\
-| search `comment("\
+| search ```\
 | sendresults subject=\"Shared dashboards not using saved searches\" msgstyle=\"table {font-family:Arial;font-size:12px;border: 1px solid black;padding:3px}th {background-color:#AAAAAA;color:#fff;border-left: solid 1px #e9e9e9} td {border:solid 1px #e9e9e9}\" showemail=f showsubj=f\
 | fields app, searchInfo\
 | eval currtime=now()\
 | outputlookup dashboard_automated_app_history.csv append=true\
-")`
+```
 
 [ForwarderLevel - Splunk HEC issues]
 action.keyindicator.invert = 0
@@ -5630,7 +5630,7 @@ search = | rest /servicesNS/-/-/data/ui/views `splunkadmins_restmacro` \
 | eval viztokens=replace(viztokens,"\$","\\$")\
 | makemv tokenizer=(\S+) viztokens\
 | eval viztokens=split(viztokens,",") \
-| search `comment("This would be more accurate as such but make the search really, really slow...so combining into 1 large value...\
+| search ```This would be more accurate as such but make the search really, really slow...so combining into 1 large value...\
 | streamfilter fieldname=rowtoken_matches pattern=rowtokens rowsearch\
 | streamfilter fieldname=paneltoken_matches pattern=paneltokens panelsearch\
 | streamfilter fieldname=chartoken_matches pattern=charttokens chartsearch\
@@ -5639,7 +5639,7 @@ search = | rest /servicesNS/-/-/data/ui/views `splunkadmins_restmacro` \
 | streamfilter fieldname=singletoken_matches pattern=singletokens singlesearch\
 | streamfilter fieldname=tabletoken_matches pattern=tabletokens tablesearch\
 | streamfilter fieldname=viztoken_matches pattern=viztokens vizsearch\
-")`\
+```\
 | eval combined=mvappend(rowsearch, panelsearch, chartsearch, eventsearch, mapsearch, singlesearch, tablesearch, vizsearch)\
 | eval combinedtokens=mvappend(rowtokens, paneltokens, charttokens, eventtokens, maptokens, singletokens, tabletokens, viztokens)\
 | eval counter=mvcount(combinedtokens) \

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -43,7 +43,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Find any failures to send emails due to either the size of the email or the email server not working or similar")`\
+search = ```Find any failures to send emails due to either the size of the email or the email server not working or similar```\
 index=_internal `splunkenterprisehosts` "stderr from " python* sendemail.py sourcetype=splunkd (`splunkadmins_splunkd_source`)\
 | eval message=coalesce(message,event_message)\
 | dedup message \
@@ -74,10 +74,10 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("runScript errors are an indicator of a potential issue with an application")`\
+search = ```runScript errors are an indicator of a potential issue with an application```\
 index=_internal `splunkenterprisehosts` sourcetype=splunkd (`splunkadmins_splunkd_source`) \
 ("ERROR ScriptRunner" "stderr from '*python* *runScript.py execute'") OR ("ERROR ExecProcessor" "message from \"python* *ERROR*")\
-`comment("Do not include INFO level messages from standard error/out")`\
+```Do not include INFO level messages from standard error/out```\
 NOT " INFO " `splunkadmins_runscript` \
 | cluster showcount=true \
 | fields host, _raw, cluster_count
@@ -105,7 +105,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("crash logs on the Splunk enterprise servers are usually an issue, this may require a support ticket")`\
+search = ```crash logs on the Splunk enterprise servers are usually an issue, this may require a support ticket```\
 index=_internal `splunkenterprisehosts` sourcetype=splunkd_crash_log\
 | top source, host, sourcetype
 disabled = 1
@@ -128,8 +128,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Any Splunk enterprise servers running less than 64000 file descriptors can result in a crash, therefore we watch the ulimit numbers on startup")` \
-`comment("You could do | rest /services/server/sysinfo | table ulimit* or similar but that will not cover all Splunk enterprise servers that are in the _internal index...")`\
+search = ```Any Splunk enterprise servers running less than 64000 file descriptors can result in a crash, therefore we watch the ulimit numbers on startup``` \
+```You could do | rest /services/server/sysinfo | table ulimit* or similar but that will not cover all Splunk enterprise servers that are in the _internal index...```\
 index=_internal ("ulimit" "open files:") OR ("fd limit" "lower") ( `splunkenterprisehosts` sourcetype=splunkd (`splunkadmins_splunkd_source`) ) \
 | rex "(?P<nooffiles>\d+) files" \
 | where nooffiles<64000 OR searchmatch("fd limit")\
@@ -155,7 +155,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Deployment clients can pull applications down but they may not install the application so we watch for this error to see if an application failed to install")` \
+search = ```Deployment clients can pull applications down but they may not install the application so we watch for this error to see if an application failed to install``` \
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) action=Install OR action=download log_level=WARN OR log_level=ERROR\
 | cluster t=0.9 showcount=true \
 | where cluster_count>1 \
@@ -186,7 +186,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("A time skew issue likely shows an issue on the endpoint forwarder rather than a Splunk server but it is useful to watch for")`\
+search = ```A time skew issue likely shows an issue on the endpoint forwarder rather than a Splunk server but it is useful to watch for```\
 index=_internal "A time skew of approximately" (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) sourcetype=splunkd `splunkadmins_timeskew`\
 | rex "Peer:https?://(?P<hostname>[^:]+).*A time skew of approximately (?P<seconds>-?\d+)"\
 | eval negativeSeconds=if(substr(seconds,0,1)="-","true", "false"), seconds=abs(seconds)\
@@ -216,7 +216,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This usually indicates a misconfigured serverclass.conf or a missing application from the deployment-apps directory")` \
+search = ```This usually indicates a misconfigured serverclass.conf or a missing application from the deployment-apps directory``` \
 index=_internal `deploymentserverhosts` "ERROR Serverclass" "Failed to load app." sourcetype=splunkd (`splunkadmins_splunkd_source`) \
 | bin _time span=20m \
 | top Application, path, _time
@@ -242,7 +242,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This looks for unusual changes on the phone home to the deployment server, this alert can also be completely harmless")` \
+search = ```This looks for unusual changes on the phone home to the deployment server, this alert can also be completely harmless``` \
 index=_internal `deploymentserverhosts` "has changed some of its properties on the latest phone home.Old properties are" (`splunkadmins_splunkd_source`) sourcetype=splunkd `splunkadmins_changedprops`\
 | rex "Client with Id '(?P<clientid>[^']+)" \
 | sort clientid \
@@ -250,7 +250,7 @@ index=_internal `deploymentserverhosts` "has changed some of its properties on t
 | where count>`splunkadmins_changedprops_count` \
 | stats values(ip) AS "IP List", values(dns) AS "DNS names", values(hostname) AS "Hostname List", values(uts) AS uts by name \
 | eval numberOfIPs=mvcount("IP List"), numberOfHostnames=mvcount("Hostname List") \
-| search `comment("Having multiple DNS names for an IP address is almost normal here, however multiple IPs or hostnames might be a real issue. Ignoring multiple DNS names only")` numberOfIPs>1 OR numberOfHostnames>1
+| search ```Having multiple DNS names for an IP address is almost normal here, however multiple IPs or hostnames might be a real issue. Ignoring multiple DNS names only``` numberOfIPs>1 OR numberOfHostnames>1
 disabled = 1
 
 [DeploymentServer - btool validation failures occurring on deployment server]
@@ -271,7 +271,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This alert detects when the deployment server is throwing some kind of warning about an application it is going to deploy. The exclusion list includes lines that are not really relevant as they appear later in the log entries")` \
+search = ```This alert detects when the deployment server is throwing some kind of warning about an application it is going to deploy. The exclusion list includes lines that are not really relevant as they appear later in the log entries``` \
 index=_internal `deploymentserverhosts` "WARN  Application" sourcetype=splunkd (`splunkadmins_splunkd_source`)\
  NOT "There were the following errors in btool check:" \
 `splunkadmins_btoolvalidation_ds` \
@@ -302,7 +302,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This alert detects universal or heavy forwarders that have hit the maxKbps setting in the limits.conf and might need to be investigated")` \
+search = ```This alert detects universal or heavy forwarders that have hit the maxKbps setting in the limits.conf and might need to be investigated``` \
 index=_internal "has reached maxKBps. As a result, data forwarding may be throttled" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) `splunkadmins_bandwidth`\
 | bin _time span=1h\
 | stats count as countPerHost by host, _time\
@@ -332,16 +332,16 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins 
 request.ui_dispatch_view = search
-search = `comment("An experimental alert to detect the seekcrc too small errors in the splunkd.log file occurring a bit too regularly")` \
+search = ```An experimental alert to detect the seekcrc too small errors in the splunkd.log file occurring a bit too regularly``` \
 index=_internal "File too small to check seekcrc, probably truncated" \
 sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) `splunkadmins_toosmall_checkcrc`\
-`comment("Older universal forwarders have a variety of logs that will never be more than zero sized, therefore this error is legitimate for them")`\
+```Older universal forwarders have a variety of logs that will never be more than zero sized, therefore this error is legitimate for them```\
 NOT (file="'/*/splunkforwarder/var/log/splunk/license_usage.log'" OR file="'/*/splunkforwarder/var/log/splunk/license_usage_summary.log'" OR file="'/*/splunkforwarder/var/log/splunk/mongod.log'" OR file="'/*/splunkforwarder/var/log/splunk/remote_searches.log'" OR file="'/*/splunkforwarder/var/log/splunk/scheduler.log'" OR file="'/*/splunkforwarder/var/log/splunk/searchhistory.log'" OR file="'/*/splunkforwarder/var/log/splunk/splunkd_ui_access.log'" OR file="'/*/splunkforwarder/var/log/splunk/crash-*'" OR file="'/*/splunkforwarder/var/log/splunk/btool.log'" OR file="'/*/splunkforwarder/var/log/splunk/license_audit.log'")\
-`comment("Older windows based universal forwarders can also have these same zero sized log files, therefore this error is legitimate for them")`\
+```Older windows based universal forwarders can also have these same zero sized log files, therefore this error is legitimate for them```\
 NOT (file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\license_usage.log'" OR file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\license_usage_summary.log'" OR file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\mongod.log'" OR file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\remote_searches.log'" OR file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\scheduler.log'" OR file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\searchhistory.log'" OR file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\splunkd_ui_access.log'" OR file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\crash-*'" OR file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\btool.log'" OR file="'\\*\\SplunkUniversalForwarder\\var\\log\\splunk\\license_audit.log'")\
-`comment("Splunk enterprise instances running on non-official hostnames")`\
+```Splunk enterprise instances running on non-official hostnames```\
 NOT (file="'/opt/splunk/var/log/splunk/license_usage.log'" OR file="'/opt/splunk/var/log/splunk/license_usage_summary.log'" OR file="'/opt/splunk/var/log/splunk/mongod.log'" OR file="'/opt/splunk/var/log/splunk/remote_searches.log'" OR file="'/opt/splunk/var/log/splunk/scheduler.log'" OR file="'/opt/splunk/var/log/splunk/searchhistory.log'" OR file="'/opt/splunk/var/log/splunk/splunkd_ui_access.log'" OR file="'/opt/splunk/var/log/splunk/crash-*'" OR file="'/opt/splunk/var/log/splunk/btool.log'" OR file="'/opt/splunk/var/log/splunk/license_audit.log'")\
-`comment("Regex for filename now replaces the default field extraction due to Windows based filenames containing spaces..")`\
+```Regex for filename now replaces the default field extraction due to Windows based filenames containing spaces..```\
 | rex "file=(?P<file>.+)\)\."\
 | stats sum(linecount) as numberOfEntries by host, file\
 | where numberOfEntries > 10
@@ -370,7 +370,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("If a forwarder restarts more than 5 times in 15 minutes there might be a problematic script that is restarting it too often")` \
+search = ```If a forwarder restarts more than 5 times in 15 minutes there might be a problematic script that is restarting it too often``` \
 index=_internal "Received shutdown signal." sourcetype=splunkd (`splunkadmins_splunkuf_source`)\
 | stats count as restartCount by host \
 | where restartCount > 5
@@ -396,7 +396,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Excessive SSL errors may relate to a bug in the universal forwarder, if the SSL errors relate to duplication this could cause a license usage issue")` \
+search = ```Excessive SSL errors may relate to a bug in the universal forwarder, if the SSL errors relate to duplication this could cause a license usage issue``` \
 index=_internal sourcetype=splunkd (`splunkadmins_splunkuf_source`) NOT (`splunkenterprisehosts`)\
 "sock_error = 10054. SSL Error = error:00000000:lib(0):func(0):reason(0)"\
 | top limit=500 host
@@ -426,7 +426,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | metadata type=hosts index=_internal \
-| search `comment("Find forwarders that have recently stopped talking to the indexers / appear to be down")`\
+| search ```Find forwarders that have recently stopped talking to the indexers / appear to be down```\
 NOT (`splunkenterprisehosts`) `splunkadmins_forwarderdown`\
 | eval age=now()-recentTime | eval status=if(age<1200,"UP","DOWN") \
 | eval "Last Active On"=strftime(recentTime, "%+") \
@@ -457,7 +457,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Find if the HTTP listener cannot cope with the incoming load of data. Refer to https://docs.splunk.com/Documentation/Splunk/latest/Troubleshooting/HTTPthreadlimitissues for more information")` \
+search = ```Find if the HTTP listener cannot cope with the incoming load of data. Refer to https://docs.splunk.com/Documentation/Splunk/latest/Troubleshooting/HTTPthreadlimitissues for more information``` \
 index=_internal HttpListener "Can't handle request for" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkenterprisehosts`
 disabled = 1
 
@@ -480,7 +480,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Find splunk sources sending excessive amounts of logs in and then conditionally email the right team members")` \
+search = ```Find splunk sources sending excessive amounts of logs in and then conditionally email the right team members``` \
 index=_internal `splunkadmins_license_usage_source` type=Usage `licensemasterhost` sourcetype=splunkd `splunkadmins_heavylogging`\
 | stats sum(b) as totalBytes by s, h, idx, st \
 | eval totalMBInPast30Mins=round(totalBytes/1024/1024) \
@@ -509,7 +509,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The file descriptor cache full message is a potential indicator that we are monitoring directories with many files and this might cause the forwarder to utilize extra CPU")`\
+search = ```The file descriptor cache full message is a potential indicator that we are monitoring directories with many files and this might cause the forwarder to utilize extra CPU```\
 index=_internal TailReader "File descriptor cache is full" (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) sourcetype=splunkd `splunkadmins_exceeding_filedescriptor`\
 | eval message=coalesce(message,event_message)\
 | stats values(message), count by host
@@ -536,9 +536,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("A could not send data to output queue from the indexers or heavy forwarders often indicates a performance issue")` \
+search = ```A could not send data to output queue from the indexers or heavy forwarders often indicates a performance issue``` \
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) "Could not send data to output queue" (`indexerhosts`) OR (`heavyforwarderhosts`) `splunkadmins_sending_data`\
-| search `comment("Exclude shutdown times")` AND NOT [`splunkadmins_shutdown_time(indexerhosts,0,0)`]\
+| search ```Exclude shutdown times``` AND NOT [`splunkadmins_shutdown_time(indexerhosts,0,0)`]\
 | bin _time span=20m\
 | stats count by host, _time\
 | search (count>`splunkadmins_sending_data_nonhf_count` NOT `heavyforwarderhosts`) OR (count>`splunkadmins_sending_data_hf_count` `heavyforwarderhosts`)
@@ -564,7 +564,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect universal forwarders that do not have any disk space left and therefore cannot work as expected")` \
+search = ```Detect universal forwarders that do not have any disk space left and therefore cannot work as expected``` \
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) "No space left on device" \
 | top host
 disabled = 1
@@ -592,7 +592,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 schedule_window = 50
-search = `comment("Detect universal forwarders that have the ulimit set too low for the number of file descriptors (ulimit -n)")` \
+search = ```Detect universal forwarders that have the ulimit set too low for the number of file descriptors (ulimit -n)``` \
 index=_internal log_level=WARN sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) (component=ulimit "Splunk may not work due to low file size limit") OR ("fd limit" "lower") \
 | dedup host \
 | fields host _raw
@@ -618,10 +618,10 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The number of warnings about duplication seems unusually high and may require investigation")` \
-`comment("The duplication warnings will occur with indexer acknowledgement enabled and indexer shutdowns. Other circumstances likely require some kind of investigation, the issue may also appear if the forwarder is having trouble getting CPU time...")`\
+search = ```The number of warnings about duplication seems unusually high and may require investigation``` \
+```The duplication warnings will occur with indexer acknowledgement enabled and indexer shutdowns. Other circumstances likely require some kind of investigation, the issue may also appear if the forwarder is having trouble getting CPU time...```\
 index=_internal sourcetype=splunkd (`splunkadmins_splunkuf_source`) NOT (`splunkenterprisehosts`) "duplication" `splunkadmins_unusual_duplication`\
-| search `comment("Exclude shutdown times")` AND NOT [`splunkadmins_shutdown_time(indexerhosts,60,60)`]\
+| search ```Exclude shutdown times``` AND NOT [`splunkadmins_shutdown_time(indexerhosts,60,60)`]\
 | stats count by host \
 | where count > `splunkadmins_unusual_duplication_count`
 disabled = 1
@@ -649,11 +649,11 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Look for issues relating to CRC salt on any files...the universal forwarder settings may need tweaking to ensure the file is read as expected, or it may be a rolled file")` \
+search = ```Look for issues relating to CRC salt on any files...the universal forwarder settings may need tweaking to ensure the file is read as expected, or it may be a rolled file``` \
 index=_internal "You may wish to use larger initCrcLen for this sourcetype" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) `splunkadmins_crcsalt_initcrc`\
-`comment("Attempt to exclude rolled files from the check by looking for the most common pattern (.1, .2, .10 or similar)")` \
-`comment("This alert aims to find files where crcSalt = <SOURCE> might be required in the inputs.conf file or a tweak to the initCrcLen...")`\
-`comment("Regex for filename now replaces the default field extraction due to Windows based filenames containing spaces..")`\
+```Attempt to exclude rolled files from the check by looking for the most common pattern (.1, .2, .10 or similar)``` \
+```This alert aims to find files where crcSalt = <SOURCE> might be required in the inputs.conf file or a tweak to the initCrcLen...```\
+```Regex for filename now replaces the default field extraction due to Windows based filenames containing spaces..```\
 | rex "file=(?P<file>.+)\)\."\
 | regex file!="\.\d+$" \
 | eval message=coalesce(message,event_message)\
@@ -682,8 +682,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect universal forwarders that appear to be moving their clocks backwards/into the past or forwards, into the future. Timeshifting servers may need to be excluded from Splunk")` \
-`comment("The string \"WARN TimeoutHeap - Either time adjusted forwards by, or event loop was descheduled for\" looks similar but tends to relate to a poorly performing server rather than a time shift...")`\
+search = ```Detect universal forwarders that appear to be moving their clocks backwards/into the past or forwards, into the future. Timeshifting servers may need to be excluded from Splunk``` \
+```The string \"WARN TimeoutHeap - Either time adjusted forwards by, or event loop was descheduled for\" looks similar but tends to relate to a poorly performing server rather than a time shift...```\
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) "Detected system time adjusted" OR "System time went " `splunkadmins_uf_timeshifting`\
 | rex "by (?P<timePeriod>\d+)ms\.$"\
 | rex "by (?P<timePeriodInSecs>[\d\.]+) seconds$"\
@@ -715,7 +715,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /services/cluster/searchhead/generation `splunkadmins_clustermaster_host` | where is_searchable!=1 OR replication_factor_met!=1 OR search_factor_met!=1 | table is_searchable replication_factor_met, search_factor_met\
-| search `comment("If the cluster master advises there is an issue, you probably want to check why")`
+| search ```If the cluster master advises there is an issue, you probably want to check why```
 disabled = 1
 
 [IndexerLevel - Future Dated Events that appeared in the last week]
@@ -737,7 +737,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Data should not appear from the future...this alert finds that data so it can be investigated")` `comment("This query could be | tstats count, max(_time), min(_time) where index=* earliest=+5m latest=+10y groupby index, sourcetype, _time, _indextime span=1d, and then drop the field named 'ahead', but in 8.2.5 this is slower than the index= version")` \
+search = ```Data should not appear from the future...this alert finds that data so it can be investigated``` ```This query could be | tstats count, max(_time), min(_time) where index=* earliest=+5m latest=+10y groupby index, sourcetype, _time, _indextime span=1d, and then drop the field named 'ahead', but in 8.2.5 this is slower than the index= version``` \
 index=* earliest=+5m latest=+10y `splunkadmins_future_dated`\
 | eval ahead=abs(now() - _time)\
 | eval indextime=_indextime\
@@ -772,29 +772,29 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Timestamp parsing has failed, and it doesn't appear to be related to the event been broken due to having too many lines, that is a separate alert that may trigger a timestamp parsing issue (excluded from this alert as that issue needs to be resolved first)")` \
-`comment("Please note that you may see this particular warning on data that is sent to the nullQueue using a transforms.conf. Obviously you won't see this in the index but you will see the warning because the time parsing occurs before the transforms.conf occurs")`\
-`comment("This alert now checks for at least 2 failures, and header entries can often trigger 2 entries in the log files about timestamp parsing failures...")`\
-`comment("Finally one strange edge case is a newline inserted into the log file (by itself with no content before/afterward) can trigger the warning but nothing will get indexed, multiline_event_extra_waittime, time_before_close and EVENT_BREAKER can resolve this edge case")`\
+search = ```Timestamp parsing has failed, and it doesn't appear to be related to the event been broken due to having too many lines, that is a separate alert that may trigger a timestamp parsing issue (excluded from this alert as that issue needs to be resolved first)``` \
+```Please note that you may see this particular warning on data that is sent to the nullQueue using a transforms.conf. Obviously you won't see this in the index but you will see the warning because the time parsing occurs before the transforms.conf occurs```\
+```This alert now checks for at least 2 failures, and header entries can often trigger 2 entries in the log files about timestamp parsing failures...```\
+```Finally one strange edge case is a newline inserted into the log file (by itself with no content before/afterward) can trigger the warning but nothing will get indexed, multiline_event_extra_waittime, time_before_close and EVENT_BREAKER can resolve this edge case```\
 index=_internal sourcetype=splunkd ("Failed to parse timestamp" "Defaulting to timestamp of previous event") OR "Breaking event because limit of " OR "outside of the acceptable time window" (`splunkadmins_splunkd_source`) (`indexerhosts`) OR (`heavyforwarderhosts`) `splunkadmins_failuretoparse_timestamp`\
 | bin _time span=`splunkadmins_failuretoparse_timestamp_binperiod` \
 | eval host=data_host, source=data_source, sourcetype=data_sourcetype\
 | rex "source::(?P<source>[^|]+)\|host::(?P<host>[^|]+)\|(?P<sourcetype>[^|]+)" \
 | eventstats count(eval(isnotnull(data_host))) AS hasBrokenEventOrTuncatedLine, count(eval(searchmatch("outside of the acceptable time window"))) AS outsideTimewindow by _time, host, source, sourcetype\
 | where hasBrokenEventOrTuncatedLine=0 AND isnull(data_host) AND NOT searchmatch("outside of the acceptable time window")\
-| search `comment("To investigate further we want the previous timestamp that Splunk used for the event in question, that way we can see what it looks like in raw format...")`\
+| search ```To investigate further we want the previous timestamp that Splunk used for the event in question, that way we can see what it looks like in raw format...```\
 | rex "Defaulting to timestamp of previous event \((?P<previousTimeStamp>[^)]+)"\
 | eval previousTimeStamp=strptime(previousTimeStamp, "%a %b %d %H:%M:%S %Y")\
 | stats count, min(_time) AS firstSeen, max(_time) AS mostRecent, first(previousTimeStamp) AS recentExample, sum(outsideTimewindow) AS outsideTimewindow by host, sourcetype, source\
 | where count>`splunkadmins_failuretoparse_timestamp_count`\
 | stats sum(count) AS count, min(firstSeen) AS firstSeen, max(mostRecent) AS mostRecent, first(recentExample) AS recentExample, values(source) AS sourceList, sum(outsideTimewindow) AS outsideTimewindow by host, sourcetype\
-| search `comment("Allow exclusions based on count or similar...")` `splunkadmins_failuretoparse_timestamp2`\
+| search ```Allow exclusions based on count or similar...``` `splunkadmins_failuretoparse_timestamp2`\
 | eval invesEnd=recentExample+1\
 | eval invesDataSource=sourceList\
 | eval invesDataSource=if(mvcount(invesDataSource)>1,mvjoin(invesDataSource,"\" OR source=\""),invesDataSource)\
 | eval invesDataSource = "source=\"" + invesDataSource + "\""\
 | eval invesDataSource = replace(invesDataSource, "\\\\", "\\\\\\\\")\
-| eval investigationQuery="`comment(\"The investigation query may find zero data if the data was sent to the null queue by a transforms.conf as the time parsing occurs before the transforms occur. If this source/sourcetype has a null queue you may need to exclude it from this alert\")` `comment(\"Note that the host= can be inaccurate if host overrides are in use in transforms.conf, if this query finds no results remove host=...\")` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" " . invesDataSource . " earliest=" . recentExample . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")" \
+| eval investigationQuery="```\"The investigation query may find zero data if the data was sent to the null queue by a transforms.conf as the time parsing occurs before the transforms occur. If this source/sourcetype has a null queue you may need to exclude it from this alert\``` ```\"Note that the host= can be inaccurate if host overrides are in use in transforms.conf, if this query finds no results remove host=...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" " . invesDataSource . " earliest=" . recentExample . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")" \
 | eval mostRecent=strftime(mostRecent, "%+"), firstSeen=strftime(firstSeen, "%+")\
 | eval outsideAcceptableTimeWindow=if(outsideTimewindow!=0,"Timestamp parsing failed due to been outside the acceptable time window","No")\
 | fields - recentExample, invesEnd, invesDataSource, outsideTimewindow\
@@ -821,8 +821,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("IndexConfig warnings are generally a problem")` \
-index=_internal "WARN  IndexConfig" OR "ERROR IndexConfig" OR (ClusterMasterControlHandler " ERROR " OR " WARN " NOT "*No new dry run will be performed" `comment("This appears to occur when CM is not aware of a hot->warm roll, self-recovers in most cases as the .bucketManifest/directory is fine according to support")`  NOT "The cluster manager already has committed size for this bucket") (`splunkadmins_splunkd_source`) `indexerhosts` OR `cluster_masters` `splunkadmins_indexconfig_warn` \
+search = ```IndexConfig warnings are generally a problem``` \
+index=_internal "WARN  IndexConfig" OR "ERROR IndexConfig" OR (ClusterMasterControlHandler " ERROR " OR " WARN " NOT "*No new dry run will be performed" ```This appears to occur when CM is not aware of a hot->warm roll, self-recovers in most cases as the .bucketManifest/directory is fine according to support```  NOT "The cluster manager already has committed size for this bucket") (`splunkadmins_splunkd_source`) `indexerhosts` OR `cluster_masters` `splunkadmins_indexconfig_warn` \
 | eval message=coalesce(message,event_message) \
 | stats count by message, host \
 | eval why="Bundle validation failure on indexing tier, please investigate" \
@@ -850,7 +850,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This alert is borrowed from the monitoring console. When the queues are filled there is an issue in the indexer cluster!")`\
+search = ```This alert is borrowed from the monitoring console. When the queues are filled there is an issue in the indexer cluster!```\
 index=_internal `indexerhosts` `splunkadmins_metrics_source` sourcetype=splunkd group=queue \
 | eval ingest_pipe = if(isnotnull(ingest_pipe), ingest_pipe, "none") | search ingest_pipe=*\
 | eval name=case(name=="aggqueue","2 - Aggregation Queue",\
@@ -893,8 +893,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("If the replication queue is full, then depending on the replication factor this can stop / slow indexing. Note this alert has been set to find many results to remove false alarms...")` \
-`comment("Unfortunately this setting is not tunable, at the time of writing (7.0.0) the queue size is 20. If the \"has room now\" appears shortly afterward this is not an issue.")`\
+search = ```If the replication queue is full, then depending on the replication factor this can stop / slow indexing. Note this alert has been set to find many results to remove false alarms...``` \
+```Unfortunately this setting is not tunable, at the time of writing (7.0.0) the queue size is 20. If the \"has room now\" appears shortly afterward this is not an issue.```\
 index=_internal `indexerhosts` "replication queue for " "full" sourcetype=splunkd (`splunkadmins_splunkd_source`)\
 | rename peer AS guid \
 | join guid [| rest /services/search/distributed/peers `splunkadmins_restmacro` | fields guid peerName]\
@@ -920,7 +920,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("If this alert fires, we are potentially out of disk in the hot section or something else has gone wrong")` \
+search = ```If this alert fires, we are potentially out of disk in the hot section or something else has gone wrong``` \
 index=_internal `indexerhosts` "Not rolling hot buckets on further errors to this target" sourcetype=splunkd (`splunkadmins_splunkd_source`)
 disabled = 1
 
@@ -946,7 +946,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Either the master is down or the indexers are having issues contacting the master or search head to master is having issues")` \
+search = ```Either the master is down or the indexers are having issues contacting the master or search head to master is having issues``` \
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) (`splunkenterprisehosts` CMSearchHead OR GenerationGrabber OR (CMMasterProxy down)) OR (`indexerhosts` cluster master CMSlave WARN OR ERROR)\
 NOT [`splunkadmins_shutdown_time(splunkadmins_clustermaster_oshost,30,60)`]\
 | fillnull master value="N/A"\
@@ -978,7 +978,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | tstats summariesonly=t count WHERE index="*" by splunk_server _time span=10m\
-| search `comment("If the balance of data between indexer cluster members becomes very unbalanced then the searches tend to spend more CPU on a particular indexer / search peer and this eventually creates issues")`\
+| search ```If the balance of data between indexer cluster members becomes very unbalanced then the searches tend to spend more CPU on a particular indexer / search peer and this eventually creates issues```\
 | sort _time \
 | eventstats sum(count) AS totalCountForTime, dc(splunk_server) AS indexers by _time \
 | eval perc=round((count/totalCountForTime)*100,2) \
@@ -1006,15 +1006,15 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events...")` \
-`comment("If running Splunk 7 or newer than refer to the monitoring console Indexing -> Inputs -> Data Quality")`\
+search = ```The event that came in was greater than the maximum number of lines that were configured, therefore it was broken into multiple events...``` \
+```If running Splunk 7 or newer than refer to the monitoring console Indexing -> Inputs -> Data Quality```\
 index=_internal AggregatorMiningProcessor "Breaking event because limit of" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkadmins_weekly_brokenevents`\
 | rex "Breaking event because limit of (?P<curlimit>\d+)" \
 | stats max(_time) AS mostRecent, min(_time) AS firstSeen, count by data_sourcetype, data_host, curlimit\
 | eval longerThan=curlimit-1\
 | eval invesLatest = if(mostRecent==firstSeen,mostRecent+1,mostRecent)\
 | rename data_sourcetype AS sourcetype, data_host AS host\
-| eval investigationQuery="`comment(\"If no results are found prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\")` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" linecount>" . longerThan . " earliest=" . firstSeen . " latest=" . invesLatest\
+| eval investigationQuery="```\"If no results are found prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" linecount>" . longerThan . " earliest=" . firstSeen . " latest=" . invesLatest\
 | fields - firstSeen, longerThan, invesLatest\
 | eval mostRecent=strftime(mostRecent, "%+")\
 | sort - count
@@ -1039,9 +1039,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)")`\
-`comment("If running Splunk 7 or newer than refer to the Monitoring Console, Indexing -> Inputs -> Data Quality")`\
-`comment("If you are in a (very) performance sensitive environment you might want to remove the rex/eval lines for the data_host field and let the admin update the inves query manually")`\
+search = ```The line was truncated due to length, the TRUNCATE setting may need tweaking (or it may be just bad data coming in)```\
+```If running Splunk 7 or newer than refer to the Monitoring Console, Indexing -> Inputs -> Data Quality```\
+```If you are in a (very) performance sensitive environment you might want to remove the rex/eval lines for the data_host field and let the admin update the inves query manually```\
 index=_internal "Truncating line because limit of" sourcetype=splunkd (`splunkadmins_splunkd_source`) (`heavyforwarderhosts`) OR (`indexerhosts`) `splunkadmins_weekly_truncated`\
 | rex "Truncating line because limit of (?P<curlimit>\d+) bytes.*with a line length >= (?P<approxlinelength>\S+)" \
 | rex field=data_host "(?P<data_host>[^\.]+)"\
@@ -1054,7 +1054,7 @@ index=_internal "Truncating line because limit of" sourcetype=splunkd (`splunkad
 | eval invesLastSeen=if(firstSeen==lastSeen,lastSeen+1,lastSeen)\
 | eval firstSeen=firstSeen-10\
 | eval invesLastSeen=invesLastSeen+10\
-| eval investigationQuery="`comment(\"Find examples where the truncation limit has been reached\")` `comment(\"The earliest/latest time is based on the warning messages in the Splunk logs, they may need customisation!\")` index=* sourcetype=" . sourcetype . " " . hostList . " earliest=" . firstSeen . " latest=" . invesLastSeen . " | where len(_raw)=" . curlimit\
+| eval investigationQuery="```\"Find examples where the truncation limit has been reached\``` ```\"The earliest/latest time is based on the warning messages in the Splunk logs, they may need customisation!\``` index=* sourcetype=" . sourcetype . " " . hostList . " earliest=" . firstSeen . " latest=" . invesLastSeen . " | where len(_raw)=" . curlimit\
 | sort - count\
 | eval lastSeen=strftime(lastSeen, "%+")\
 | table sourcetype, curlimit, count, avgApproxLineLength, maxApproxLineLength, lastSeen, investigationQuery\
@@ -1081,25 +1081,25 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The timestamp parsing did run but the timestamp found did not match previous events so the time parsing may need a review")`\
+search = ```The timestamp parsing did run but the timestamp found did not match previous events so the time parsing may need a review```\
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) (`indexerhosts`) OR (`heavyforwarderhosts`) \
 "outside of the acceptable time window. If this timestamp is correct, consider adjusting" \
 OR "is too far away from the previous event's time" \
 OR "is suspiciously far away from the previous event's time" `splunkadmins_valid_timestamp_invalidparsed`\
 | rex "source::(?P<source>[^|]+)\|host::(?P<host>[^|]+)\|(?P<sourcetype>[^|]+)"\
-| search `comment("The goal of this part of the search was to obtain the messages that are relating to this particular host/source/sourcetype, however since the message includes a time we cannot uses values(message) without getting a huge number of values, therefore we use cluster to obtain the unique values. Since we want the original start/end times we use labelonly=true")`\
+| search ```The goal of this part of the search was to obtain the messages that are relating to this particular host/source/sourcetype, however since the message includes a time we cannot uses values(message) without getting a huge number of values, therefore we use cluster to obtain the unique values. Since we want the original start/end times we use labelonly=true```\
 | cluster labelonly=true \
 | eval message=coalesce(message,event_message)\
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen, first(message) AS message by host, source, sourcetype, cluster_label\
-| search `comment("While 'A possible timestamp match (...) is outside of the acceptable time window' and 'Time parsed (...) is too far away from the previous event's time', result in the current indexing time been used, the 'Accepted time (...) is suspiciously far away from the previous event's time' is accepted and therefore we need to expand the investigation query time to include this time range as well!")` \
+| search ```While 'A possible timestamp match (...) is outside of the acceptable time window' and 'Time parsed (...) is too far away from the previous event's time', result in the current indexing time been used, the 'Accepted time (...) is suspiciously far away from the previous event's time' is accepted and therefore we need to expand the investigation query time to include this time range as well!``` \
 | rex field=message "Accepted time \((?P<acceptedTime>[^\)]+)"\
 | eval acceptedTime=strptime(acceptedTime, "%a %b %d %H:%M:%S %Y")\
 | eval firstSeen=if(acceptedTime<firstSeen,acceptedTime,firstSeen)\
-| search `comment("Now that we have the first message for each labelled cluster, we now take all relevant message per host/source/sourcetype")`\
+| search ```Now that we have the first message for each labelled cluster, we now take all relevant message per host/source/sourcetype```\
 | stats values(acceptedTime) AS acceptedTime, sum(count) AS count, min(firstSeen) AS firstSeen, max(lastSeen) AS lastSeen, values(message) AS message by host, source, sourcetype\
 | eval invesEnd=if(lastSeen=firstSeen,round(lastSeen+1),round(lastSeen)), invesStart=floor(firstSeen)\
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\")\
-| eval investigationQuery="`comment(\"Please note that this query may need to be narrowed down further before running it, this is an example only...\")` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" earliest=" . invesStart . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"\
+| eval investigationQuery="```\"Please note that this query may need to be narrowed down further before running it, this is an example only...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" earliest=" . invesStart . " latest=" . invesEnd . " | eval indextime=strftime(_indextime, \"%+\")"\
 | eval firstSeen=strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")\
 | table host, source, sourcetype count, firstSeen, lastSeen, message, investigationQuery\
 | sort - count
@@ -1126,14 +1126,14 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Find any search running longer than a period of time, this is useful for tracking down poorly built search queries or dashboards")` \
+search = ```Find any search running longer than a period of time, this is useful for tracking down poorly built search queries or dashboards``` \
 index=_audit sourcetype=audittrail info=completed  \
 `splunkenterprisehosts` \
-`comment("Exclude accelerated searches")` \
+```Exclude accelerated searches``` \
 savedsearch_name!=_ACCELERATE*\
 total_run_time>300\
 `splunkadmins_longrunning_searches`\
-`comment("At this point we have a list of searches minus the various exclusions, we now filter out the real time searches as they will always run for a long period of time...")`\
+```At this point we have a list of searches minus the various exclusions, we now filter out the real time searches as they will always run for a long period of time...```\
 | regex search_id!="rt.*" | table savedsearch_name, search_id, total_run_time, search_et, search_lt, api_et, api_lt, scan_count, _time, user, info, host | eval search_et=strftime(search_et, "%d/%m/%Y %H:%M"), search_lt=strftime(search_lt, "%d/%m/%Y %H:%M"), api_et=strftime(api_et, "%d/%m/%Y %H:%M"), api_lt=strftime(api_lt, "%d/%m/%Y %H:%M"), _time=strftime(_time, "%d/%m/%Y %H:%M")
 disabled = 1
 
@@ -1160,7 +1160,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/saved/searches `splunkadmins_restmacro` timeout=900 \
-| search `comment("Find realtime scheduled searches, they should not be enabled")` `splunkadmins_realtime_scheduledsearches`\
+| search ```Find realtime scheduled searches, they should not be enabled``` `splunkadmins_realtime_scheduledsearches`\
 | table title author, realtime_schedule, cron_schedule, description, disabled, dispatch.earliest_time, dispatch.index_earliest, dispatch.index_latest, dispatch.latest_time, dispatchAs, eai:acl.app, eai:acl.owner, eai:acl.owner, updated, qualifiedSearch, is_scheduled, next_scheduled_time, alert_type, schedule_priority\
 | search dispatch.earliest_time=rt* next_scheduled_time!=""
 disabled = 1
@@ -1185,13 +1185,13 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("These searches are scheduled but for some reason cannot run (eg. invalid search syntax)")`\
+search = ```These searches are scheduled but for some reason cannot run (eg. invalid search syntax)```\
 index=_internal `searchheadhosts` sourcetype=scheduler NOT "The 'require' command received zero" `splunkadmins_scheduledsearches_cannot_run`\
-`comment("Additional rex due to someone using app= inside their saved search name...")`\
+```Additional rex due to someone using app= inside their saved search name...```\
 | rex "app=\"(?P<app>[^\"]+)\""\
 | eval message=coalesce(message,event_message)\
 | fillnull message\
-| search `comment("The below 3 lines will catch map/lookup errors or similar that look like message=\"Error in 'map': Did not find value for required attribute 'attr'.\". No actions executed. This may or may not be a good thing...")` \
+| search ```The below 3 lines will catch map/lookup errors or similar that look like message=\"Error in 'map': Did not find value for required attribute 'attr'.\". No actions executed. This may or may not be a good thing...``` \
 | rex "- savedsearch_id=\"(?P<user2>[^;]+);(?P<app2>[^;]+);(?P<savedsearch_name_2>[^\"]+)" \
 | eval savedsearch_name=coalesce(savedsearch_name,savedsearch_name_2), app=coalesce(app,app2), user=coalesce(user,user2) \
 | fillnull status value="error" \
@@ -1208,9 +1208,9 @@ index=_internal `searchheadhosts` sourcetype=scheduler NOT "The 'require' comman
     | stats max(_time) AS mostRecentlySeen, first(message) AS message by savedsearch_name, app, log_level, user, status, search_head_cluster] \
 | selfjoin overwrite=true keepsingle=true savedsearch_name, app, user, search_head_cluster \
 | append \
-    [ search `comment("macro failures in the search syntax result in the log only appearing in splunkd, and the absence of delegated_remote_completion in scheduler.log")` \
+    [ search ```macro failures in the search syntax result in the log only appearing in splunkd, and the absence of delegated_remote_completion in scheduler.log``` \
         index=_internal `searchheadhosts` ERROR "failed job" sourcetype=splunkd `splunkadmins_splunkd_source` saved_search=* \
-    | search `comment("Exclude time periods where shutdowns were occurring")` AND NOT \
+    | search ```Exclude time periods where shutdowns were occurring``` AND NOT \
         [ `splunkadmins_shutdown_time(searchheadhosts,0,0)`] \
     | rex "saved_search=([^;]+);(?P<app>[^;]+);(?P<savedsearch_name>.*?) err=" \
     | rex "(?P<messagewithoutheader>saved_search=.*uri=)http(s)?://[^/]+(?P<messagewithoutheader2>.*)" \
@@ -1253,7 +1253,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/saved/searches `splunkadmins_restmacro` \
-| search `comment("Find scheduled searches where they are searching over all time, this is generally not good practice and can cause performance issues")`\
+| search ```Find scheduled searches where they are searching over all time, this is generally not good practice and can cause performance issues```\
 dispatch.earliest_time="" OR dispatch.earliest_time="0" next_scheduled_time!="" `splunkadmins_scheduledsearches_without_earliestlatest`\
 | table title author, realtime_schedule, cron_schedule, description, disabled, dispatch.earliest_time, dispatch.latest_time, eai:acl.app, eai:acl.owner, updated, qualifiedSearch, is_scheduled, is_visible, next_scheduled_time, splunk_server \
 | regex qualifiedSearch="^\s*(search|tstats) " \
@@ -1287,7 +1287,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/saved/searches `splunkadmins_restmacro`\
-| search `comment("Look over all scheduled searches and find those not specifying/narrowing down to an index, or using the index=* trick")`\
+| search ```Look over all scheduled searches and find those not specifying/narrowing down to an index, or using the index=* trick```\
 | table title, eai:acl.owner, description, eai:acl.app, qualifiedSearch, next_scheduled_time\
 | search next_scheduled_time!="" `splunkadmins_scheduledsearches_without_index` \
 | regex qualifiedSearch!=".*index\s*(!?)=\s*([^*]|\*\S+)" \
@@ -1317,7 +1317,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Shell scripts running from Splunk are failing to run or throwing errors, or another sendmodalert failure has occurred")` \
+search = ```Shell scripts running from Splunk are failing to run or throwing errors, or another sendmodalert failure has occurred``` \
 index=_internal `searchheadhosts` sourcetype=splunkd log_level="ERROR" OR log_level="WARN" `splunkadmins_scriptfailures` command="runshellscript" OR ScriptRunner OR "Alert script returned error code" OR "ERROR sendmodalert" OR "WARN  sendmodalert" OR "Killing script" OR ("ERROR SearchScheduler" "sendalert") NOT sendemail.py NOT "InsecureRequestWarning" \
 | bin _time span=30s \
 | eval search_head=host\
@@ -1371,7 +1371,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Once the max historic search limit has been reached the search jobs will be queued, this can be an issue if the limit is set too low (or too high)")` \
+search = ```Once the max historic search limit has been reached the search jobs will be queued, this can be an issue if the limit is set too low (or too high)``` \
 index=_internal `splunkenterprisehosts` "The maximum number of historical concurrent system-wide searches has been reached" OR "The system is approaching the maximum number of historical searches that can be run concurrently" (`splunkadmins_splunkd_source`) \
 | fields _time, host
 disabled = 1
@@ -1395,9 +1395,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("For some reason this search had to be skipped, this might be due to over scheduling the search or an inefficient search or similar")` index=_internal sourcetype=scheduler status=skipped source=*scheduler.log `splunkenterprisehosts` \
-| search `comment("Exclude unable to distribute to peer messages where we sent the shutdown signal to the peer")` AND NOT [`splunkadmins_shutdown_list(splunkenterprisehosts,0,0)`]\
-| search `comment("Skipped searches can be expected for up-to 10 minutes after an indexer(s) has been shutdown...")` AND NOT [`splunkadmins_shutdown_time(indexerhosts,0,600)`]\
+search = ```For some reason this search had to be skipped, this might be due to over scheduling the search or an inefficient search or similar``` index=_internal sourcetype=scheduler status=skipped source=*scheduler.log `splunkenterprisehosts` \
+| search ```Exclude unable to distribute to peer messages where we sent the shutdown signal to the peer``` AND NOT [`splunkadmins_shutdown_list(splunkenterprisehosts,0,0)`]\
+| search ```Skipped searches can be expected for up-to 10 minutes after an indexer(s) has been shutdown...``` AND NOT [`splunkadmins_shutdown_time(indexerhosts,0,600)`]\
 | fillnull concurrency_category concurrency_context concurrency_limit\
 | stats count, earliest(_time) AS firstSeen, latest(_time) AS lastSeen by savedsearch_id, reason, app, concurrency_category, concurrency_context, concurrency_limit, search_type, user, host \
 | eval firstSeen = strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")
@@ -1423,7 +1423,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The listed users have reached the search quota and may need to be informed of this, or they may need to be added to the macro for this alert")`\
+search = ```The listed users have reached the search quota and may need to be informed of this, or they may need to be added to the macro for this alert```\
 index=_internal `searchheadhosts` (`splunkadmins_splunkd_source`) "was previously reported to be hung but has completed" OR "The maximum number of concurrent " `splunkadmins_users_violating_searchquota`\
 | rex "Queued job id\s+=\s+(rt_)?(?P<username2>[^_]+)"\
 | eval username=coalesce(username, username2)\
@@ -1452,22 +1452,22 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The listed users have reached the maximum disk quota, they may be unaware so it is best to let them know about this issue...")` \
-`comment("Note that the REST API call accesses the jobs list which can expire for ad-hoc jobs in 10 minutes, so this may find zero results. The status.csv inside the dispatch directory records the size per job but it is not indexed by Splunk so either this alert needs to run very often or it will sometimes run after the issue has occurred and send an empty top 10 jobs list...")`\
-`comment("The introspection index version is called SearchHeadLevel - Users exceeding the disk quota introspection, it is not search head specific but it is also less accurate for disk space used")`\
+search = ```The listed users have reached the maximum disk quota, they may be unaware so it is best to let them know about this issue...``` \
+```Note that the REST API call accesses the jobs list which can expire for ad-hoc jobs in 10 minutes, so this may find zero results. The status.csv inside the dispatch directory records the size per job but it is not indexed by Splunk so either this alert needs to run very often or it will sometimes run after the issue has occurred and send an empty top 10 jobs list...```\
+```The introspection index version is called SearchHeadLevel - Users exceeding the disk quota introspection, it is not search head specific but it is also less accurate for disk space used```\
 index=_internal sourcetype=splunkd `splunkenterprisehosts` (`splunkadmins_splunkd_source`) "maximum disk usage quota" `splunkadmins_users_exceeding_diskquota`\
 | stats max(_time) AS mostRecent by username, reason, host\
 | eval mostRecent = strftime(mostRecent, "%+")\
-| search `comment("We use this bizarre field naming so when we append the actual search results we don't have 20 columns of data to read, also it looks nicer in an email. However since we want this over multiple lines and we only want to run the map command once we use a temporary field which we later expand to a multi-line field. Furthermore mvexpand on the search field can result in multiple rows per search which is why a temporary field is used")`\
+| search ```We use this bizarre field naming so when we append the actual search results we don't have 20 columns of data to read, also it looks nicer in an email. However since we want this over multiple lines and we only want to run the map command once we use a temporary field which we later expand to a multi-line field. Furthermore mvexpand on the search field can result in multiple rows per search which is why a temporary field is used```\
 | eval renameToSearch="Why am I, " + username + ", receiving this? |" + reason + " (from) " + host + "|_|Last seen? |" + mostRecent + "|_|Your top 10 largest jobs are listed below"\
 | fields - reason, mostRecent, host\
-| search `comment("The below is the complex attempt to include the largest jobs by querying the REST API. If we use map without the appendpipe we lose the original reason why we are sending this email. The initial workaround of makeresults and eval commands did work but this seemed slightly cleaner. Although there would be other ways to do this...")`\
+| search ```The below is the complex attempt to include the largest jobs by querying the REST API. If we use map without the appendpipe we lose the original reason why we are sending this email. The initial workaround of makeresults and eval commands did work but this seemed slightly cleaner. Although there would be other ways to do this...```\
 | append [ | makeresults | eval username="workaround for map errors", body="to pass appinspect" ]\
 | appendpipe\
     [\
 | map \
     [| rest /services/search/jobs `splunkadmins_restmacro` \
-    | search `comment("Attempt to show the customer the top 10 jobs using disk and the related search commands/search names, also if it relates to their scheduled searches or not...")` author=$username$ diskUsage>0 \
+    | search ```Attempt to show the customer the top 10 jobs using disk and the related search commands/search names, also if it relates to their scheduled searches or not...``` author=$username$ diskUsage>0 \
     | fields diskUsage, eai:acl.app, latestTime, label, provenance, runDuration, searchEarliestTime, searchLatestTime, title, updated, ttl \
     | rename title AS search, eai:acl.app AS app, label AS searchName \
     | sort - diskUsage \
@@ -1508,7 +1508,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("An attempt to find the execprocessor errors these are often scripts or application which are having some kind of issue...")`\
+search = ```An attempt to find the execprocessor errors these are often scripts or application which are having some kind of issue...```\
 index=_internal "ERROR ExecProcessor" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) NOT "Ignoring: \"" `splunkadmins_execprocessor`\
 | eval message=coalesce(message,event_message)\
 | dedup message, host | fields host _raw
@@ -1534,14 +1534,14 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This search detects when the time format has changed within the files 1 or more times, the time format per sourcetype should be consistent")`\
+search = ```This search detects when the time format has changed within the files 1 or more times, the time format per sourcetype should be consistent```\
 index=_internal DateParserVerbose "Accepted time format has changed" sourcetype=splunkd (`splunkadmins_splunkd_source`) (`indexerhosts`) OR (`heavyforwarderhosts`) `splunkadmins_timeformat_change`\
 | rex "source(?:=|::)(?<source>[^\|]+)\|host(?:=|::)(?<host>[^\|]+)\|(?<sourcetype>[^\|]+)"\
 | eval message=coalesce(message,event_message)\
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen by host, source, sourcetype, message\
 | eval invesMaxTime=if(firstSeen=lastSeen,lastSeen+1,lastSeen)\
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\")\
-| eval potentialInvestigationQuery="`comment(\"If no results are found, prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\")` sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" host=" . host . " earliest=" . firstSeen . " latest=" . invesMaxTime . " | eval start=substr(_raw, 0, 30) | cluster field=start"\
+| eval potentialInvestigationQuery="```\"If no results are found, prepend the earliest=/latest= with _index_ (eg _index_earliest=...) and expand the timeframe searched over, as the parsed timestamps from the data does not have to exactly match the time the warnings appeared...\``` sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" host=" . host . " earliest=" . firstSeen . " latest=" . invesMaxTime . " | eval start=substr(_raw, 0, 30) | cluster field=start"\
 | eval firstSeen=strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")\
 | fields - invesMaxTime, invesDataSource\
 | sort - count
@@ -1568,7 +1568,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The cold volume is causing indexes to be trimmed, this may or may not be an issue...")` \
+search = ```The cold volume is causing indexes to be trimmed, this may or may not be an issue...``` \
 index=_internal `indexerhosts` sourcetype=splunkd (`splunkadmins_splunkd_source`) "Size exceeds max, will have to trim " volume!="hot"\
 | fields host, _raw
 disabled = 1
@@ -1593,10 +1593,10 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("These searches were scheduled to run at a particular time but the actual run time was more than X seconds later, which might indicate a search head performance issue")` \
-`comment("In the environment this search was created on restarts are not overly common so we assume any restart might relate to a scheduling delay to prevent false alarms from the alert. This may need further tuning or you may wish to remove the where clause in this if you want more alerting.")`\
+search = ```These searches were scheduled to run at a particular time but the actual run time was more than X seconds later, which might indicate a search head performance issue``` \
+```In the environment this search was created on restarts are not overly common so we assume any restart might relate to a scheduling delay to prevent false alarms from the alert. This may need further tuning or you may wish to remove the where clause in this if you want more alerting.```\
 index=_internal `splunkenterprisehosts` sourcetype=scheduler app=* scheduled_time=* source=*scheduler.log\
-| search `comment("Exclude time periods where shutdowns were occurring")` AND NOT [`splunkadmins_shutdown_list(splunkenterprisehosts,600,600)`]\
+| search ```Exclude time periods where shutdowns were occurring``` AND NOT [`splunkadmins_shutdown_list(splunkenterprisehosts,600,600)`]\
 | eval time=strftime(_time,"%+") \
 | eval delay_in_start = (dispatch_time - scheduled_time) \
 | where delay_in_start>100\
@@ -1628,7 +1628,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The listed users have attempted to login but were unable to, it is likely they do not have any LDAP role yet and should be informed of this")` \
+search = ```The listed users have attempted to login but were unable to, it is likely they do not have any LDAP role yet and should be informed of this``` \
 index=_internal `searchheadhosts` "Couldn't find matching groups for user" OR "but none are mapped to Splunk roles" OR "SSO failed - User does not exist" (`splunkadmins_splunkd_source`) `splunkadmins_loginattempts`\
 | join user [search index=_internal `searchheadhosts` action=login status=failure reason=user-initiated OR reason=sso-failed] \
 | dedup user \
@@ -1655,8 +1655,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The indexer is freezing buckets due to disk space pressure before the frozenTimePeriodInSecs limit has been reached, this could be a problem if it is not expected...")`\
-`comment("_introspection defaults to size based so exclude it")` \
+search = ```The indexer is freezing buckets due to disk space pressure before the frozenTimePeriodInSecs limit has been reached, this could be a problem if it is not expected...```\
+```_introspection defaults to size based so exclude it``` \
 index=_internal `indexerhosts` sourcetype=splunkd (`splunkadmins_splunkd_source`) BucketMover "will attempt to freeze" NOT "because frozenTimePeriodInSecs=" \
 `splunkadmins_bucketfrozen`\
 | rex field=bkt "(rb_|db_)(?P<newestDataInBucket>\d+)_(?P<oldestDataInBucket>\d+)"\
@@ -1685,7 +1685,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The indexer has run out of disk space, this requires immediate investigation...")` \
+search = ```The indexer has run out of disk space, this requires immediate investigation...``` \
 index=_internal "event=onFileWritten err=\"disk out of space\"" OR "event=replicationData status=failed err=\"onFileWritten failed\"" `indexerhosts` (`splunkadmins_splunkd_source`) sourcetype=splunkd \
 | top host
 disabled = 1
@@ -1710,8 +1710,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Core dumps are disabled, if a crash occurs the Splunk Support team might not be able to assist without the core dump")`\
-`comment("https://answers.splunk.com/answers/223838/why-are-my-ulimits-settings-not-being-respected-on.html applies to core limits so if the server has been rebooted the init.d may need a ulimit -Hc/Sc setting for this as well...")`\
+search = ```Core dumps are disabled, if a crash occurs the Splunk Support team might not be able to assist without the core dump```\
+```https://answers.splunk.com/answers/223838/why-are-my-ulimits-settings-not-being-respected-on.html applies to core limits so if the server has been rebooted the init.d may need a ulimit -Hc/Sc setting for this as well...```\
 index=_internal "WARN  ulimit" "Core file generation disabled" `splunkenterprisehosts` sourcetype=splunkd (`splunkadmins_splunkd_source`) \
 | stats max(_time) AS mostRecentlySeen by host\
 | eval mostRecentlySeen = strftime(mostRecentlySeen, "%+")
@@ -1744,18 +1744,18 @@ request.ui_dispatch_view = search
 search = | tstats count groupby host, source\
 | append \
     [ search\
-        `comment("This search looks for insufficient permissions errors, the problem here is that we might have insufficient permissions to read a file but we might later obtain the correct permissions and then read the file (as permissions changes can happen *after* the file creation...this is why there is both a tstats listing all files (only done because I cannot find a nicer way to do this, map is possibly more compute intensive), and then a search for files")`\
+        ```This search looks for insufficient permissions errors, the problem here is that we might have insufficient permissions to read a file but we might later obtain the correct permissions and then read the file (as permissions changes can happen *after* the file creation...this is why there is both a tstats listing all files (only done because I cannot find a nicer way to do this, map is possibly more compute intensive), and then a search for files```\
         index=_internal "Insufficient permissions to read file" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`)\
     | rex "\(hint: (?P<hint>[^\)]+)"\
     | stats min(_time) AS firstSeen, max(_time) AS mostRecent, values(hint) AS hint by file, host \
     | rex field=file "'(?P<source>[^']+)'" \
     | eval insufficientpermissions="true" \
     | fields firstSeen, mostRecent, source, host, insufficientpermissions, hint] \
-| search `comment("Ignore any files requested by the macro, i.e. source!= or host!= or similar...")` `splunkadmins_permissions`\
+| search ```Ignore any files requested by the macro, i.e. source!= or host!= or similar...``` `splunkadmins_permissions`\
 | stats sum(count) AS count, min(firstSeen) AS firstSeen, max(mostRecent) AS mostRecent, values(insufficientpermissions) AS insufficientpermissions, values(hint) AS hint by host, source \
-| search `comment("If we have an insufficient permissions error, did we see no data from our tstats command?")` insufficientpermissions="true" NOT count=* `splunkadmins_insufficient_permissions`\
-    `comment("At this point if we see an insufficient permissions line, and we cannot see a result from the tstats showing indexed data from that file, then we have an issue, if not there is no issue with permisisons!")` \
-    `comment("Insufficient permissions to read file + hint: No such file or directory when the file exists on a Splunk enterprise instance might require TAILING_SKIP_READ_CHECK = 1 in the splunk-launch.conf refer to splunk support for more info")` \
+| search ```If we have an insufficient permissions error, did we see no data from our tstats command?``` insufficientpermissions="true" NOT count=* `splunkadmins_insufficient_permissions`\
+    ```At this point if we see an insufficient permissions line, and we cannot see a result from the tstats showing indexed data from that file, then we have an issue, if not there is no issue with permisisons!``` \
+    ```Insufficient permissions to read file + hint: No such file or directory when the file exists on a Splunk enterprise instance might require TAILING_SKIP_READ_CHECK = 1 in the splunk-launch.conf refer to splunk support for more info``` \
 | eval invesSource=replace(source, "\\\\", "\\\\\\\\") \
 | addinfo \
 | eval investigationQuery="index=_internal \"Insufficient permissions to read file\" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) earliest=" . info_min_time . " latest=" . info_max_time . " host=" . host . " file=\"'" . invesSource . "'\""\
@@ -1783,10 +1783,10 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("A paused TCP output processor is a potential indicator of an index performance issue, you may wish to ignore the shorter pause times such as 10 seconds if this is creating too many alerts...")`\
-`comment("On the indexer side you may see 'WARN TcpInputProc - Stopping all listening ports. Queues blocked for more than...' OR 'WARN TcpInputProc - Started listening on tcp ports. Queues unblocked', if there are indexer performance issues...")`\
+search = ```A paused TCP output processor is a potential indicator of an index performance issue, you may wish to ignore the shorter pause times such as 10 seconds if this is creating too many alerts...```\
+```On the indexer side you may see 'WARN TcpInputProc - Stopping all listening ports. Queues blocked for more than...' OR 'WARN TcpInputProc - Started listening on tcp ports. Queues unblocked', if there are indexer performance issues...```\
 index=_internal "paused" "data flow" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) `splunkadmins_tcpoutput_paused`\
-| search `comment("Exclude shutdown times")` AND NOT [`splunkadmins_shutdown_time(indexerhosts,60,60)`]\
+| search ```Exclude shutdown times``` AND NOT [`splunkadmins_shutdown_time(indexerhosts,60,60)`]\
 | rex "has been blocked for (blocked_seconds=)?(?P<timeperiod>\d+)"\
 | eval message=coalesce(message,event_message)\
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen, first(message) AS message, max(timeperiod) AS maxInSeconds, avg(timeperiod) AS avgTimePeriod by host\
@@ -1814,8 +1814,8 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | dbinspect index=* state=warm\
-| search `comment("Once the warmdb bucket count is reached then the buckets are moved to cold, this may be an issue if incorrectly configured, this alert warns in advance if we get close to the limit")`\
-`comment("This might be a bug in 6.5.2 but the buckets are printed twice by dbinspect in some cases...")` `splunkadmins_warmdbcount`\
+| search ```Once the warmdb bucket count is reached then the buckets are moved to cold, this may be an issue if incorrectly configured, this alert warns in advance if we get close to the limit```\
+```This might be a bug in 6.5.2 but the buckets are printed twice by dbinspect in some cases...``` `splunkadmins_warmdbcount`\
 | dedup bucketId, splunk_server\
 | stats count AS theCount by index, splunk_server\
 | stats avg(theCount) AS averageCount, max(theCount) AS maxCount, min(theCount) AS minCount, values(splunk_server) by index\
@@ -1849,7 +1849,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = index=_internal source="*streamfwd.log" ERROR OR FATAL `splunkadmins_streamerrors`\
-| search `comment("Exclude time periods where shutdowns were occurring")` AND NOT [`splunkadmins_shutdown_time(searchheadhosts,0,0)`]\
+| search ```Exclude time periods where shutdowns were occurring``` AND NOT [`splunkadmins_shutdown_time(searchheadhosts,0,0)`]\
 | cluster showcount=true\
 | fields host, _raw
 disabled = 1
@@ -1875,15 +1875,15 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("If we see a failed to get LDAP user 'username' from any configured servers then that is a sign the user is no longer in the company. However if there is also a message of Couldn't find matching groups for that same user it is more likely that they exist but just do not have access to Splunk")`\
-`comment("If you see this alert fire, than you probably need to cleanup the (for example) /opt/splunk/etc/users/... directory on each search head due to a user leaving/becoming disabled in LDAP. Alternatively they have a savedsearch/dashboard that you can find in the .meta files on the search head(s)")`\
+search = ```If we see a failed to get LDAP user 'username' from any configured servers then that is a sign the user is no longer in the company. However if there is also a message of Couldn't find matching groups for that same user it is more likely that they exist but just do not have access to Splunk```\
+```If you see this alert fire, than you probably need to cleanup the (for example) /opt/splunk/etc/users/... directory on each search head due to a user leaving/becoming disabled in LDAP. Alternatively they have a savedsearch/dashboard that you can find in the .meta files on the search head(s)```\
 index=_internal `searchheadhosts` "Failed to get LDAP user=\"" OR "Couldn't find matching groups for user=" OR (HTTPAuthManager "SSO failed - User does not exist") sourcetype=splunkd (`splunkadmins_splunkd_source`)\
 | eval message=coalesce(message,event_message)\
 | dedup message \
 | rex "SSO failed - User does not exist: (?P<user>\S+)"\
 | stats count, values(message) AS messages, values(component), AS components values(log_level), max(_time) AS lastSeen by user, host\
-| search `comment("count=1 eliminates users who are failing to login...if a user is active in LDAP but fails to login we should not not get a 'Couldn't find matching groups for user' line in the logs")`\
-`comment("If we are using a single sign on system and a user without any groups attempts sign on we should see the SSO failed - User does not exist: <username> message")`\
+| search ```count=1 eliminates users who are failing to login...if a user is active in LDAP but fails to login we should not not get a 'Couldn't find matching groups for user' line in the logs```\
+```If we are using a single sign on system and a user without any groups attempts sign on we should see the SSO failed - User does not exist: <username> message```\
 | where user!="undefined" AND user!="nobody" AND like(messages,"Failed to get LDAP user%") AND NOT like(messages,"SSO failed - User does not exist%")\
 | table user, messages, lastSeen, host\
 | eval lastSeen=strftime(lastSeen, "%+")
@@ -1907,7 +1907,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Failed to install app can appear *if* the application is installed to a particular targetRepositoryLocation (for example /opt/splunk/etc/deployment-apps or similar) and stateOnClient=noop is not added to the application within serverclass.conf")`\
+search = ```Failed to install app can appear *if* the application is installed to a particular targetRepositoryLocation (for example /opt/splunk/etc/deployment-apps or similar) and stateOnClient=noop is not added to the application within serverclass.conf```\
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) ("ERROR DeployedServerclass" "name=* Failed to install") OR (DeployedApplication "Installing app=")\
 | eventstats count(eval(log_level="ERROR")) AS errorCount, count(eval(log_level="INFO")) AS successCount by host, app \
 | where errorCount>0 AND successCount<1
@@ -1933,7 +1933,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Unable to distribute to peer messages often indicate downtime or serious performance issues. The Unable to distribute to peer named status=Down scenario can also result from having many indexers and this may require an increase to the timeouts in distsearch.conf")`\
+search = ```Unable to distribute to peer messages often indicate downtime or serious performance issues. The Unable to distribute to peer named status=Down scenario can also result from having many indexers and this may require an increase to the timeouts in distsearch.conf```\
 index=_internal "Unable to distribute to peer named" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkenterprisehosts` `splunkadmins_unable_distribute_to_peer`\
 | rex "(?P<message>Unable to distribute to peer named (?P<peer>[^: ]+))"\
 | bin _time span=1m\
@@ -1943,7 +1943,7 @@ index=_internal "Unable to distribute to peer named" sourcetype=splunkd (`splunk
     | rex field=title "(?P<title>[^:]+)"\
     | rename title AS peer ]\
 | eval targetHost=if(isnotnull(peerName),peerName,peer)\
-| search `comment("Exclude unable to distribute to peer messages where we sent the shutdown signal to the peer")` AND NOT [`splunkadmins_shutdown_list(splunkenterprisehosts,0,0)`]\
+| search ```Exclude unable to distribute to peer messages where we sent the shutdown signal to the peer``` AND NOT [`splunkadmins_shutdown_list(splunkenterprisehosts,0,0)`]\
 | stats count, values(message) AS message, values(host) AS reportingHostList by _time, targetHost \
 | eval reportingHostList=mvindex(reportingHostList,0,9)\
 | sort - _time\
@@ -1963,7 +1963,7 @@ display.visualizations.charting.chart = line
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to find alerts that are scheduled but not firing any actions, the alerts may need further review or may no longer be required. The app regex is in here because of some creative alert naming, X:app=Y is a real alert name in my environment!")`\
+search = ```Attempt to find alerts that are scheduled but not firing any actions, the alerts may need further review or may no longer be required. The app regex is in here because of some creative alert naming, X:app=Y is a real alert name in my environment!```\
 index=_internal source="*scheduler.log" sourcetype=scheduler `searchheadhosts` alert_actions!="" \
 | rex ", app=\"(?P<app>[^\"]+)\","\
 | stats count by savedsearch_name, app \
@@ -1992,7 +1992,7 @@ display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /services/admin/summarization by_tstats=t `splunkadmins_restmacro` count=0 \
-| search `comment("Found on https://answers.splunk.com/answers/555005/how-to-check-the-percent-of-the-dm-acceleration-co.html ")`\
+| search ```Found on https://answers.splunk.com/answers/555005/how-to-check-the-percent-of-the-dm-acceleration-co.html ```\
 | eval datamodel=replace('summary.id',"DM_".'eai:acl.app'."_","") \
 | join type=left datamodel \
   [| rest /services/data/models `splunkadmins_restmacro` count=0 \
@@ -2024,13 +2024,13 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/data/ui/views `splunkadmins_restmacro`\
-| search `comment("A dashboard searching all indexes is an issue just like a scheduled search querying all indexes or using the index=* trick")`\
+| search ```A dashboard searching all indexes is an issue just like a scheduled search querying all indexes or using the index=* trick```\
 eai:data=*query* `splunkadmins_dashboards_allindexes`\
 | regex eai:data="<search.*" \
 | rex field=eai:data "(?s)(?P<theSearch><search(?!String)[^>]*>[^<]*<query>.*?)<\/query>" max_match=200 \
 | mvexpand theSearch \
 | rex field=theSearch "(?s)<search(?P<searchInfo>[^>]*)>[^<]*<query>(?P<theQuery>.*)" \
-| search `comment("If we are seeing post process search then we don't want to check if it has index= because that is likely only in the base query. These are also various exclusions for legitimate searches that will not involve scanning all indexes, such as rest or a savedsearch or similar")` searchInfo!="*base*"\
+| search ```If we are seeing post process search then we don't want to check if it has index= because that is likely only in the base query. These are also various exclusions for legitimate searches that will not involve scanning all indexes, such as rest or a savedsearch or similar``` searchInfo!="*base*"\
 | rename eai:appName AS application, eai:acl.sharing AS sharing, eai:acl.owner AS owner, label AS name\
 | table theQuery, application, owner, sharing, name, splunk_server, title\
 | regex theQuery!="index\s*=(?!\s*\*)" \
@@ -2062,9 +2062,9 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/saved/searches `splunkadmins_restmacro`\
-| search `comment("The problem with alerts that are configured privately is that no one beyond the author can use the results link and non-admins cannot even see the alert in Splunk!")`\
-`comment("Therefore we find anything that emails that is not shared correctly *and* anything that uses a script as often the script will include a results link.")`\
-`comment("The idea here is to let the end user know so they can share it appropriately, the noop search is excluded to remove scheduled views from this list")`\
+| search ```The problem with alerts that are configured privately is that no one beyond the author can use the results link and non-admins cannot even see the alert in Splunk!```\
+```Therefore we find anything that emails that is not shared correctly *and* anything that uses a script as often the script will include a results link.```\
+```The idea here is to let the end user know so they can share it appropriately, the noop search is excluded to remove scheduled views from this list```\
 is_scheduled=1 disabled=0 eai:acl.sharing!="global" eai:acl.sharing!="app" search!="| noop" actions!="" `splunkadmins_scheduled_incorrectsharing`\
 | eval numberOfEmailed = mvcount(split('action.email.to',"@"))-1\
 | table title, eai:acl.app, author, eai:acl.sharing, actions, action.email.to, numberOfEmailed\
@@ -2091,13 +2091,13 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest/servicesNS/-/-/data/ui/views `splunkadmins_restmacro` | regex eai:data="<(earliest|latest)(Time)?>rt"\
-| search `comment("Shows realtime search usage within dashboards")` eai:data=*query* `splunkadmins_realtime_dashboard`\
+| search ```Shows realtime search usage within dashboards``` eai:data=*query* `splunkadmins_realtime_dashboard`\
 | regex eai:data="<search.*"\
 | rex field=eai:data "(?s)(?P<theSearch><search(?!String)[^>]*>[^<]*<query>.*?)<\/query>" max_match=200 \
 | mvexpand theSearch \
 | rex field=theSearch "(?s)<search(?P<searchInfo>[^>]*)>[^<]*<query>(?P<theQuery>.*)" \
-| search searchInfo!="*base*" `comment("Exclude queries which have a base, in general they will not have a earliest/latesttime so this gets confusing")`\
-`comment("It might be possible to use mvzip / mvexpand or mvindex to match the correct earliesttime/latesttime with each search query but it proved extremely difficult. So just keeping this as-is as the dashboard needs to be reviewed if it has too many realtime searches anyway")`\
+| search searchInfo!="*base*" ```Exclude queries which have a base, in general they will not have a earliest/latesttime so this gets confusing```\
+```It might be possible to use mvzip / mvexpand or mvindex to match the correct earliesttime/latesttime with each search query but it proved extremely difficult. So just keeping this as-is as the dashboard needs to be reviewed if it has too many realtime searches anyway```\
 | rex field=eai:data "(?s)<earliest(Time)?>(?P<earliesttime>[^<]+)" max_match=200 \
 | rex field=eai:data "(?s)<latest(Time)?>(?P<latesttime>[^<]+)" max_match=200 \
 | table title, eai:appName, searchInfo, theQuery,eai:acl.owner, eai:acl.sharing, label, earliesttime, latesttime, splunk_server
@@ -2123,9 +2123,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect when transparent huge pages is enabled on a Linux server, it should be disabled.")`\
-`comment("Redhat Linux has an issue where the transparent huge pages setting changes after Splunk starts if the server was rebooted, check /sys/kernel/mm/transparent_hugepage to confirm...")`\
-`comment("| rest /services/server/sysinfo is an alternative if you want the current search head + indexers, but this will ignore other search heads...")`\
+search = ```Detect when transparent huge pages is enabled on a Linux server, it should be disabled.```\
+```Redhat Linux has an issue where the transparent huge pages setting changes after Splunk starts if the server was rebooted, check /sys/kernel/mm/transparent_hugepage to confirm...```\
+```| rest /services/server/sysinfo is an alternative if you want the current search head + indexers, but this will ignore other search heads...```\
 index=_internal "Linux transparent hugepage support, enabled=" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkenterprisehosts` enabled!="never"\
 | eval error="This configuration of transparent hugepages is known to cause serious runtime problems with Splunk. Typical symptoms include generally reduced performance and catastrophic breakdown in system resp\
 onsiveness under high memory pressure. Please fix by setting the values for transparent huge pages to \"madvise\" or preferably \"never\" via sysctl, kernel boot parameters, or other method recommended by your Linux distribution."\
@@ -2155,9 +2155,9 @@ request.ui_dispatch_view = search
 search = | tstats max(_time) AS mostRecentlySeen, max(_indextime) AS mostRecentlyIndexed, min(_time) AS earliestSeen, min(_indextime) AS earliestIndexTime , count \
     where _index_earliest=`splunkadmins_olddata_lookback`, earliest=`splunkadmins_olddata_earliest`, latest=`splunkadmins_olddata_latest` \
     groupby source, sourcetype, index, host\
-| search `comment("Find data that appears to be logged in the past, this may indicate poor timestamp parsing (or we're just ingesting really old data")` `splunkadmins_olddata`\
+| search ```Find data that appears to be logged in the past, this may indicate poor timestamp parsing (or we're just ingesting really old data``` `splunkadmins_olddata`\
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\"), invesLatestTime=mostRecentlySeen+1, invesLatestIndexTime=mostRecentlyIndexed+1\
-| eval investigationQuery="`comment(\"Narrow down to the older part of the timeline after this query runs to see the potential issue...\")` index=" . index . " source=\"" . invesDataSource . "\" sourcetype=\"" . sourcetype . "\" host=" . host . " earliest=" . earliestSeen . " latest=" . invesLatestTime . " _index_earliest=" . earliestIndexTime . " _index_latest=" . invesLatestIndexTime . " | eval indextime=strftime(_indextime, \"%+\")" \
+| eval investigationQuery="```\"Narrow down to the older part of the timeline after this query runs to see the potential issue...\``` index=" . index . " source=\"" . invesDataSource . "\" sourcetype=\"" . sourcetype . "\" host=" . host . " earliest=" . earliestSeen . " latest=" . invesLatestTime . " _index_earliest=" . earliestIndexTime . " _index_latest=" . invesLatestIndexTime . " | eval indextime=strftime(_indextime, \"%+\")" \
 | eval mostRecentlySeen=strftime(mostRecentlySeen, "%+"), mostRecentlyIndexed=strftime(mostRecentlyIndexed, "%+")\
 | sort index, host, sourcetype\
 | table index, source, sourcetype, host, mostRecentlySeen, mostRecentlyIndexed, count, investigationQuery
@@ -2184,7 +2184,7 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | tstats count where index=_internal groupby host \
 | fields host \
-| search `comment("This is an attempt to find any universal forwarders that send data into the indexers but do not phone home to the expected deployment server")` `splunkadmins_forwarders_nottalking_ds`\
+| search ```This is an attempt to find any universal forwarders that send data into the indexers but do not phone home to the expected deployment server``` `splunkadmins_forwarders_nottalking_ds`\
 | eval shortname=mvindex(split(host, "."), 0) \
 | eval talking=0 \
 | table shortname, host, talking \
@@ -2233,7 +2233,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("sendmodalert or sendalert errors and warnings may be an issue relating to the creation of alerts via a script")`\
+search = ```sendmodalert or sendalert errors and warnings may be an issue relating to the creation of alerts via a script```\
 index=_internal `splunkenterprisehosts` ("ERROR sendmodalert" action) OR ("WARN sendmodalert" action) OR "Error in 'sendalert' command" sourcetype=splunkd (`splunkadmins_splunkd_source`)\
 `comment("If you need more context on the above errors add this snippet into the above search (remove the \\):\
 OR \"sendmodalert - Invoking modular alert action\"\
@@ -2267,7 +2267,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The indexer not accepting TCP connections is either a serious performance issue or downtime")` \
+search = ```The indexer not accepting TCP connections is either a serious performance issue or downtime``` \
 index=_internal TcpOutputFd "connection refused" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) \
 | rex "Connect to (?P<clientip>[^:]+)" \
 | top clientip \
@@ -2295,7 +2295,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Buckets are moving from warm to cold very quickly and this could be an issue related to the sizing not been valid for the indexes...")` \
+search = ```Buckets are moving from warm to cold very quickly and this could be an issue related to the sizing not been valid for the indexes...``` \
 `indexerhosts` index=_internal "Will chill bucket" (`splunkadmins_splunkd_source`) sourcetype=splunkd "/db/db"  \
 | rex "=/.*?(?P<indexname>[^/]+)(/[^/]+){2} " \
 | stats count by indexname \
@@ -2323,12 +2323,12 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This read operation timed out expecting ACK will likely result in the forwarder re-sending at least some data to the indexer. This can be caused by lack of CPU on the forwarder and potentially other issues...")`\
+search = ```This read operation timed out expecting ACK will likely result in the forwarder re-sending at least some data to the indexer. This can be caused by lack of CPU on the forwarder and potentially other issues...```\
 index=_internal "Read operation timed out expecting ACK from" sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`)\
 | rex "from (?P<indexer>\S+)"\
 | stats count, max(_time) AS mostRecent by host, indexer\
 | eval mostRecent=strftime(mostRecent, "%+")\
-| search `comment("Allow exclusions such as ignoring a count per host or similar...")` `splunkadmins_readop_expectingack`
+| search ```Allow exclusions such as ignoring a count per host or similar...``` `splunkadmins_readop_expectingack`
 disabled = 1
 
 [AllSplunkEnterpriseLevel - Replication Failures]
@@ -2351,9 +2351,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Replication status failure on a search head, the search head may require a restart or investigation...")`\
-index=_internal "because replication was unsuccessful. replicationStatus Failed failure info:" OR "replicateDelta: failed for" OR (ERROR DistributedBundleReplicationManager) OR (WARN DistributedBundleReplicationManager NOT "however it took too long") `comment("These are deprecated in Splunk 9, NOT \"replicationWhitelist in distsearch.conf is deprecated\" NOT \"replicationBlacklist in distsearch.conf is deprecated\"")` `comment("This is confirmed as an invalid warning message in Splunk 9")` NOT "Failed to touch bundle=, checksum=0 (manual preparation): No such file or directory" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkenterprisehosts` `splunkadmins_repfailures`\
-| search `comment("Exclude shutdown times")` AND NOT [`splunkadmins_shutdown_keyword(indexerhosts,180,180)`]\
+search = ```Replication status failure on a search head, the search head may require a restart or investigation...```\
+index=_internal "because replication was unsuccessful. replicationStatus Failed failure info:" OR "replicateDelta: failed for" OR (ERROR DistributedBundleReplicationManager) OR (WARN DistributedBundleReplicationManager NOT "however it took too long") ```These are deprecated in Splunk 9, NOT \"replicationWhitelist in distsearch.conf is deprecated\" NOT \"replicationBlacklist in distsearch.conf is deprecated\"``` ```This is confirmed as an invalid warning message in Splunk 9``` NOT "Failed to touch bundle=, checksum=0 (manual preparation): No such file or directory" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkenterprisehosts` `splunkadmins_repfailures`\
+| search ```Exclude shutdown times``` AND NOT [`splunkadmins_shutdown_keyword(indexerhosts,180,180)`]\
 | eval event_message=coalesce(event_message,message) \
 | stats count, max(_time) AS mostRecent by host, event_message \
 | sort - mostRecent \
@@ -2384,12 +2384,12 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Use introspection data to monitor Splunk mount points, if you want to monitor non-Splunk directories use nmon or another monitoring system")`\
+search = ```Use introspection data to monitor Splunk mount points, if you want to monitor non-Splunk directories use nmon or another monitoring system```\
 index=_introspection host=* component=Partitions `splunkadmins_lowdisk`\
 | eval available='data.available', capacity='data.capacity', mount_point='data.mount_point'\
 | eval percfree = round((available/capacity)*100,2)\
 | stats min(percfree) AS percfree, min(available) AS minMBAvailable by mount_point, host\
-| search `comment("Below 10% (default only, can be changed in the macro) is an issue unless it's an indexer, as 10% of the indexer is actually a very large amount of data...")`\
+| search ```Below 10% (default only, can be changed in the macro) is an issue unless it's an indexer, as 10% of the indexer is actually a very large amount of data...```\
 (percfree<`splunkadmins_lowdisk_perc` NOT (`indexerhosts`)) OR (minMBAvailable<`splunkadmins_lowdisk_mb` (`indexerhosts`))
 disabled = 1
 
@@ -2413,7 +2413,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This ideally should never happen during normal runtime...")`\
+search = ```This ideally should never happen during normal runtime...```\
 index=_internal `searchheadhosts` "KV Store process terminated" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkadmins_kvstore_terminated`\
 | fields _time, host, _raw
 disabled = 1
@@ -2438,7 +2438,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("One or more files did not pass the startup hash-check against the Splunk provided manifest, you can tune the limits.conf to control how the warning is logged or not logged")`\
+search = ```One or more files did not pass the startup hash-check against the Splunk provided manifest, you can tune the limits.conf to control how the warning is logged or not logged```\
 index=_internal `splunkenterprisehosts` "An installed * did not pass hash-checking due to" (`splunkadmins_splunkd_source`) sourcetype=splunkd `splunkadmins_fileintegritycheck`\
 | eval message=coalesce(message,event_message)\
 | stats count, latest(_time) AS lastSeen by message, host\
@@ -2463,7 +2463,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Find potentially invalid configuration within the Splunk applications on search heads/indexers and warn about this...")` \
+search = ```Find potentially invalid configuration within the Splunk applications on search heads/indexers and warn about this...``` \
 index=_internal WARN IniFile `splunkenterprisehosts` sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkadmins_warninifile`\
 | cluster showcount=true\
 | fields _time, host, cluster_count, _raw
@@ -2487,7 +2487,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect the issue where someone has created a file longer than 100 characters and the cluster is having issues with replication. The 100 character issue was confirmed in Splunk 6.5.2 during a support case")`\
+search = ```Detect the issue where someone has created a file longer than 100 characters and the cluster is having issues with replication. The 100 character issue was confirmed in Splunk 6.5.2 during a support case```\
 index=_internal `searchheadhosts` (ArchiveFile "Failed to write archive header for" "Pathname too long") OR ("ERROR Archiver" "Unable to add entry") (`splunkadmins_splunkd_source`) sourcetype=splunkd \
 | cluster showcount=true\
 | fields _time, _raw, cluster_count
@@ -2516,9 +2516,9 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | tstats max(linecount) AS maxLineCount, min(_time) AS firstSeen, max(_time) AS mostRecent, values(host) AS hosts, count AS occurrenceCount where index=*, linecount>250 groupby sourcetype\
-| search `comment("This search detects sourcetypes with greater than 250 lines which have SHOULD_LINEMERGE set to true, this might cause blocking in the indexer aggregation queue if there are a large number")`\
-`comment("of events with hundreds of lines or very large events such as >5000 lines of data. This alert is designed to give hints about where SHOULD_LINEMERGE=false / LINE_BREAKER=... might be more appropriate")`\
-`comment("Note that the REST API will return every instance of sourcetype, it's not quite as accurate a btool so this can generate false alarms if there are multiple props.conf definitions of a sourcetype")`\
+| search ```This search detects sourcetypes with greater than 250 lines which have SHOULD_LINEMERGE set to true, this might cause blocking in the indexer aggregation queue if there are a large number```\
+```of events with hundreds of lines or very large events such as >5000 lines of data. This alert is designed to give hints about where SHOULD_LINEMERGE=false / LINE_BREAKER=... might be more appropriate```\
+```Note that the REST API will return every instance of sourcetype, it's not quite as accurate a btool so this can generate false alarms if there are multiple props.conf definitions of a sourcetype```\
 `splunkadmins_multiline_linemerge`\
 | join [| rest `splunkindexerhostsvalue` /servicesNS/-/-/configs/conf-props\
 | fields title SHOULD_LINEMERGE\
@@ -2551,7 +2551,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("LineBreakingProcessor ERROR's are usually related to misconfiguration/errors in the LINE_BREAKER= setup in props.conf and are therefore an issue. This version of the Aggregator error often relates to date time config files")`\
+search = ```LineBreakingProcessor ERROR's are usually related to misconfiguration/errors in the LINE_BREAKER= setup in props.conf and are therefore an issue. This version of the Aggregator error often relates to date time config files```\
 index=_internal (WARN CsvLineBreaker) OR ("ERROR" ("JsonLineBreaker" OR "LineBreakingProcessor" OR "AggregatorMiningProcessor") NOT "WARN  AggregatorMiningProcessor") sourcetype=splunkd (`splunkadmins_splunkd_source`) (`indexerhosts`) OR (`heavyforwarderhosts`) `splunkadmins_dataparsing_error` \
 | rex "(?s)^(\S+\s+){3}(?P<error>.*)"\
 | stats count, latest(_time) AS mostrecent, earliest(_time) AS firstseen, values(host) AS hosts by error\
@@ -2580,16 +2580,16 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect search head issues related to extended search head downtime, in particular ConfReplication issues or KV store replication issues")`\
-`comment("KVStore - http://docs.splunk.com/Documentation/Splunk/latest/Admin/ResyncKVstore , ConfReplication - http://docs.splunk.com/Documentation/Splunk/latest/DistSearch/HowconfrepoworksinSHC#Replication_synchronization_issues")`\
-`comment("The search head cluster captain is disconnected can relate to a SH cluster restart *or* if outside a rolling restart this may require a restart of the problematic search head...")`\
-`comment("In addition to this you could also look for \"Error pushing configurations to captain\" consecutiveErrors>1 , this would also hint at a potential issue although a small number of consecutive errors appears to be normal...")`\
-`comment("If you see the message \"Consider performing a destructive configuration resync on this search head cluster member\", then it's a real issue and often requires manual intervention...")` \
+search = ```Detect search head issues related to extended search head downtime, in particular ConfReplication issues or KV store replication issues```\
+```KVStore - http://docs.splunk.com/Documentation/Splunk/latest/Admin/ResyncKVstore , ConfReplication - http://docs.splunk.com/Documentation/Splunk/latest/DistSearch/HowconfrepoworksinSHC#Replication_synchronization_issues```\
+```The search head cluster captain is disconnected can relate to a SH cluster restart *or* if outside a rolling restart this may require a restart of the problematic search head...```\
+```In addition to this you could also look for \"Error pushing configurations to captain\" consecutiveErrors>1 , this would also hint at a potential issue although a small number of consecutive errors appears to be normal...```\
+```If you see the message \"Consider performing a destructive configuration resync on this search head cluster member\", then it's a real issue and often requires manual intervention...``` \
 index=_internal `searchheadhosts` "Local KV Store has replication issues" OR ("ConfReplicationThread" "captain") OR ("SHCMasterHTTPProxy" "Low Level http request" NOT "did not satisfy regex" NOT "does not exist" NOT "peer already has artifact" NOT "has inflight replications" NOT ("failed on report target request" "not found")) sourcetype=splunkd (`splunkadmins_splunkd_source`) \
 | regex "\S+\s+\S+\s+\S+\s+(ERROR|WARN)" \
 | eval search_head=host \
 | eval search_head_cluster=`search_head_cluster` \
-| search `comment("Exclude time periods where shutdowns were occurring")` AND NOT [`splunkadmins_shutdown_time(searchheadhosts,0,0)`]\
+| search ```Exclude time periods where shutdowns were occurring``` AND NOT [`splunkadmins_shutdown_time(searchheadhosts,0,0)`]\
 | cluster showcount=true t=0.93 labelonly=t \
 | fillnull value=0 consecutiveErrors \
 | stats min(_time) AS firstSeen, max(_time) AS mostRecent, values(_raw) AS _raw, max(cluster_count) AS cluster_count, max(consecutiveErrors) AS consecutiveErrors by host, cluster_label, search_head_cluster \
@@ -2617,7 +2617,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("When this issue occurs it is likely related to some kind of issue post-restart of the indexer/search head cluster. Restarting the search head cluster appears to resolve the issue in 6.5.2")`\
+search = ```When this issue occurs it is likely related to some kind of issue post-restart of the indexer/search head cluster. Restarting the search head cluster appears to resolve the issue in 6.5.2```\
 index=_internal "ERROR SHCArtifactId" "This GUID does not match the member's current GUID" sourcetype=splunkd (`splunkadmins_splunkd_source`) `searchheadhosts` \
 | eventstats max(_time) AS lasterror, min(_time) AS firsterror\
 | cluster showcount=true \
@@ -2642,7 +2642,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This warning will appear in the messages console of the license master, considering you have 72 hours to fix the issue you might want to be alerted about this so it can be fixed promptly! The scenario is likely to occur when a heavy forwarder is sending data into the indexers without using the forwarder license or talking to the cluster master.")`\
+search = ```This warning will appear in the messages console of the license master, considering you have 72 hours to fix the issue you might want to be alerted about this so it can be fixed promptly! The scenario is likely to occur when a heavy forwarder is sending data into the indexers without using the forwarder license or talking to the cluster master.```\
 index=_internal `licensemasterhost` "Duplicated License situation happen" (`splunkadmins_splunkd_source`) \
 | cluster showcount=true \
 | fields _time, host, source, _raw, cluster_count
@@ -2667,7 +2667,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("A DS_DC_Common warning normally relates to a typo within the serverclass.conf, most likely due to manual editing, this will prevent the GUI from been used for the forwarder management configuration...")`\
+search = ```A DS_DC_Common warning normally relates to a typo within the serverclass.conf, most likely due to manual editing, this will prevent the GUI from been used for the forwarder management configuration...```\
 index=_internal "WARN" "DS_DC_Common" `deploymentserverhosts` sourcetype=splunkd (`splunkadmins_splunkd_source`)\
 | eval message=coalesce(message,event_message)\
 | stats first(_time) AS lastSeen by message, host\
@@ -2694,7 +2694,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("A TcpInputConfig or SSLCommon error likely indicates a misconfiguration of a heavy forwarder or indexer, this may prevent the listening port from working as expected")`\
+search = ```A TcpInputConfig or SSLCommon error likely indicates a misconfiguration of a heavy forwarder or indexer, this may prevent the listening port from working as expected```\
 index=_internal ERROR "TcpInputConfig" OR "SSLCommon" OR "Could not bind" sourcetype=splunkd (`splunkadmins_splunkd_source`) (`indexerhosts`) OR (`heavyforwarderhosts`) \
 | eval message=coalesce(message,event_message)\
 | stats first(_time) AS mostRecent by host, source, sourcetype, message\
@@ -2720,7 +2720,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("If the error Peer ... will not return any results for this search, because the search head is using an outdated generation then either the peer requires a restart or there is another issue here. Assuming the issue does not resolve itself quickly...")`\
+search = ```If the error Peer ... will not return any results for this search, because the search head is using an outdated generation then either the peer requires a restart or there is another issue here. Assuming the issue does not resolve itself quickly...```\
 index=_internal sourcetype=splunkd `splunkadmins_splunkd_source` `indexerhosts` "because the search head is using an outdated generation"\
 | eval message=coalesce(message,event_message)\
 | stats count, min(_time) AS firstSeen, max(_time) AS lastSeen, values(host) AS host by message\
@@ -2748,7 +2748,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("A 404 error appearing on some search head peers but not others might imply a synchronisation issue within the search head cluster has occurred, this might require correction potentially through a re-sync http://docs.splunk.com/Documentation/Splunk/latest/DistSearch/HowconfrepoworksinSHC#Replication_synchronization_issues ")`\
+search = ```A 404 error appearing on some search head peers but not others might imply a synchronisation issue within the search head cluster has occurred, this might require correction potentially through a re-sync http://docs.splunk.com/Documentation/Splunk/latest/DistSearch/HowconfrepoworksinSHC#Replication_synchronization_issues ```\
 index=_internal `searchheadhosts` "find saved search with name" sourcetype=splunkd `splunkadmins_splunkd_source`\
 | rex field=err "/servicesNS/(?P<username>[^/]+)/(?P<appName>[^/]+)"\
 | rex "'(?P<searchname>[^']+)'.$"\
@@ -2775,13 +2775,13 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Too many events with the same timestamp have been found. This may be a sign of poor quality data, or a problematic log file")`\
+search = ```Too many events with the same timestamp have been found. This may be a sign of poor quality data, or a problematic log file```\
 index=_internal "Too many events" (`indexerhosts`) OR (`heavyforwarderhosts`) `splunkadmins_splunkd_source` `splunkadmins_toomany_sametimestamp`\
 | cluster showcount=true \
 | rex "Too many events \((?P<number>[0-9]+.)"\
 | rename data_host AS host, data_sourcetype AS sourcetype, data_source AS source\
 | eval invesDataSource = replace(source, "\\\\", "\\\\\\\\"), invesStartTime=floor(_time)\
-| eval investigationQuery="`comment(\"You will need to set the time settings manually as the log does not provide the parsed time, only the indexed time the issue occurred at...\")` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" _index_earliest=" . invesStartTime\
+| eval investigationQuery="```\"You will need to set the time settings manually as the log does not provide the parsed time, only the indexed time the issue occurred at...\``` index=* host=" . host . " sourcetype=\"" . sourcetype . "\" source=\"" . invesDataSource . "\" _index_earliest=" . invesStartTime\
 | eval message=coalesce(message,event_message)\
 | table host, sourcetype, source, number, cluster_count, message, _time, investigationQuery
 disabled = 1
@@ -2806,15 +2806,15 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The main goal of this alert errors which might not appear in splunkd.log but are critical to keeping the kvstore running on the search heads. Please check the mongod.log file for further information, the additional count field is simply determining that mongo is still logging...")`\
-`comment("Attempt to find errors in the mongod log and make sure the errors do not relate to shutdown events in the search head cluster. Since this does will ignore any events when either cluster shutsdown it might not be sensitive enough for some use cases...")`\
-index=_internal `searchheadhosts` `splunkadmins_mongo_source` (" E " OR " F " OR " W ") `comment("https://jira.mongodb.org/browse/SERVER-42078 advises this is harmless")` NOT "update of non-mod failed" `splunkadmins_mongodb_errors`\
+search = ```The main goal of this alert errors which might not appear in splunkd.log but are critical to keeping the kvstore running on the search heads. Please check the mongod.log file for further information, the additional count field is simply determining that mongo is still logging...```\
+```Attempt to find errors in the mongod log and make sure the errors do not relate to shutdown events in the search head cluster. Since this does will ignore any events when either cluster shutsdown it might not be sensitive enough for some use cases...```\
+index=_internal `searchheadhosts` `splunkadmins_mongo_source` (" E " OR " F " OR " W ") ```https://jira.mongodb.org/browse/SERVER-42078 advises this is harmless``` NOT "update of non-mod failed" `splunkadmins_mongodb_errors`\
 | regex _raw="^\s+?\S+\s+[EF]" \
-| search `comment("Exclude time periods where shutdowns were occurring")` AND NOT [`splunkadmins_shutdown_time(searchheadhosts,60,60)`]\
+| search ```Exclude time periods where shutdowns were occurring``` AND NOT [`splunkadmins_shutdown_time(searchheadhosts,60,60)`]\
 | eventstats max(_time) AS mostRecent, min(_time) AS firstSeen by host\
 | bin _time span=10m \
 | stats values(_raw) AS logMessages, max(mostRecent) AS mostRecent, min(firstSeen) AS firstSeen by _time, host \
-| search `comment("One final symptom that appears when mongodb is dead is the logging just stops, zero data, however this proved to be tricky in Splunk so the below query uses a few tricks to ensure the data will show zero values even if the server stops reporting. timechart was recommended by splunkanswers as it creates a timebucket with null values if no data is found...")`\
+| search ```One final symptom that appears when mongodb is dead is the logging just stops, zero data, however this proved to be tricky in Splunk so the below query uses a few tricks to ensure the data will show zero values even if the server stops reporting. timechart was recommended by splunkanswers as it creates a timebucket with null values if no data is found...```\
 | append \
     [ | tstats prestats=t count where index=_internal `searchheadhosts` `splunkadmins_mongo_source` by host, _time span=5m \
     | search `searchheadhosts`\
@@ -2828,7 +2828,7 @@ index=_internal `searchheadhosts` `splunkadmins_mongo_source` (" E " OR " F " OR
     | eval _time=now() ] \
 | eval mostRecent = strftime(mostRecent, "%+"), firstSeen=strftime(firstSeen, "%+")\
 | fields _time, host, firstSeen, mostRecent, logMessages\
-| search `comment("Just in case...")` `splunkadmins_mongodb_errors2`
+| search ```Just in case...``` `splunkadmins_mongodb_errors2`
 disabled = 1
 
 [IndexerLevel - Cold data location approaching size limits]
@@ -2851,15 +2851,15 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest `splunkindexerhostsvalue` /services/data/indexes/ \
 | search\
-    `comment("This search attempts to find indexes which are about to start rolling buckets to frozen due to disk space issues by checking how much percentage of the allocated cold section of disk is used. It does not take into account any volume sizing...")`\
-    `comment("This is the more proactive form of IndexerLevel - Buckets are been frozen due to index sizing")` \
+    ```This search attempts to find indexes which are about to start rolling buckets to frozen due to disk space issues by checking how much percentage of the allocated cold section of disk is used. It does not take into account any volume sizing...```\
+    ```This is the more proactive form of IndexerLevel - Buckets are been frozen due to index sizing``` \
 | join title splunk_server type=outer \
     [| rest `splunkindexerhostsvalue` /services/data/indexes-extended/] \
 | stats values(bucket_dirs.cold.bucket_size) AS currentColdSizeMB, values(bucket_dirs.home.warm_bucket_size) AS currentWarmSizeMB, max(bucket_dirs.home.event_max_time) AS latestTime, min(bucket_dirs.cold.event_min_time) AS earliestTime, min(bucket_dirs.home.event_min_time) AS earliestTimeHot, values(coldPath.maxDataSizeMB) AS coldPathSizeLimitMB, values(currentDBSizeMB) AS hotSizeMB, values(maxTotalDataSizeMB) AS maxTotalDataSizeMB, values(frozenTimePeriodInSecs) AS frozenTimePeriodInSecs, values(maxDataSize) AS maxDataSize, values(homePath.maxDataSizeMB) AS hotPathMaxDataSizeMB, values(bucket_dirs.home.warm_bucket_count) AS currentWarmCount, values(maxWarmDBCount) AS maxWarmDBCount by name, splunk_server \
 | eval currentColdSizeMB=coalesce(currentColdSizeMB,currentWarmSizeMB), earliestTime=coalesce(earliestTime,earliestTimeHot)\
 | eval "Days of data based on epoch values"=round((latestTime-earliestTime)/3600/24) \
 | rename name AS index, splunk_server AS indexer\
-| search  `comment("Things do get a little bit messy here, if the cold path size is unlimited, the remaining data is the maxTotalSizeMB minus what we have already used in the hot section (not a perfect calculation but close enough for our purposes")` \
+| search  ```Things do get a little bit messy here, if the cold path size is unlimited, the remaining data is the maxTotalSizeMB minus what we have already used in the hot section (not a perfect calculation but close enough for our purposes``` \
 | eval warm_bucket_percent = (100 / maxWarmDBCount) * currentWarmCount \
 | eval coldPathSizeLimitMB=case(warm_bucket_percent>95 AND coldPathSizeLimitMB==0,maxTotalDataSizeMB-currentWarmSizeMB,coldPathSizeLimitMB==0 AND hotPathMaxDataSizeMB==0,maxTotalDataSizeMB,coldPathSizeLimitMB==0 AND hotPathMaxDataSizeMB!=0,maxTotalDataSizeMB-hotPathMaxDataSizeMB,1=1,coldPathSizeLimitMB) \
 | eval percUsed=round((currentColdSizeMB/coldPathSizeLimitMB)*100,2) \
@@ -2890,7 +2890,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect when the scheduler is unable to run search commands due to a lack of disk space on the filesystem")`\
+search = ```Detect when the scheduler is unable to run search commands due to a lack of disk space on the filesystem```\
 index=_internal `splunkenterprisehosts` (sourcetype=splunkd `splunkadmins_splunkd_source` "Search not executed: Dispatch Command: The minimum free disk space") OR (sourcetype=scheduler "The minimum free disk space * reached")\
 | eval message=coalesce(message,event_message)\
 | stats count, min(_time) AS firstSeen, max(_time) AS mostRecent, max(_raw) AS lastExample by host, message\
@@ -2917,9 +2917,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to detect if an indexer crash resulted in corrupt buckets, if so alert the admin so they are aware...")`\
-`comment("The indexer is likely going to print the line \"WARN  IndexerService - Indexer was started dirty: splunkd startup may take longer than usual; searches may not be accurate until background fsck completes.\", however we also want to know if buckets were corrupted. In a clustered environment the corrupt buckets should be added to the cluster master fixup list and repaired online, if a non-clustered environment refer to the Splunk fsck documentation. Note that I'm unable to find a log message to advise when the OnlineFsck completes in splunkd.log. You may also wish to refer to alert IndexerLevel - Corrupt buckets via DBInspect")`\
-`comment("FYI fixup lines in the splunkd log file may look like \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds.\"")`\
+search = ```Attempt to detect if an indexer crash resulted in corrupt buckets, if so alert the admin so they are aware...```\
+```The indexer is likely going to print the line \"WARN  IndexerService - Indexer was started dirty: splunkd startup may take longer than usual; searches may not be accurate until background fsck completes.\", however we also want to know if buckets were corrupted. In a clustered environment the corrupt buckets should be added to the cluster master fixup list and repaired online, if a non-clustered environment refer to the Splunk fsck documentation. Note that I'm unable to find a log message to advise when the OnlineFsck completes in splunkd.log. You may also wish to refer to alert IndexerLevel - Corrupt buckets via DBInspect```\
+```FYI fixup lines in the splunkd log file may look like \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds.\"```\
 index=_internal sourcetype=splunkd `splunkadmins_splunkd_source` `indexerhosts` "At restart after an unclean shutdown found bucket path" OR ("finished moving hot to warm" caller=init_roll) OR (OnlineFsck "Scheduled repair fsck* kind='entire bucket'")\
 | rex field=path "(?P<pathWithoutHot>.*)(/|\\\\)\S+"\
 | join type=outer pathWithoutHot \
@@ -2959,8 +2959,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Find any LDAP groups that are reporting that they do not exist so can therefore be removed from the Splunk configuration")`\
-`comment("This appears to occur only after restarts of the Splunk server, however it is useful to know about as the authentication.conf can be cleaned up once found")`\
+search = ```Find any LDAP groups that are reporting that they do not exist so can therefore be removed from the Splunk configuration```\
+```This appears to occur only after restarts of the Splunk server, however it is useful to know about as the authentication.conf can be cleaned up once found```\
 index=_internal sourcetype=splunkd `splunkenterprisehosts` `splunkadmins_splunkd_source` "was not found on the LDAP server"\
 | eval message=coalesce(message,event_message)\
 | stats max(_time) AS mostRecentlySeen, min(_time) AS firstSeen by message, host\
@@ -3008,7 +3008,7 @@ display.visualizations.trellis.splitBy = PeerName
 request.ui_dispatch_app = SplunkAdmins 
 request.ui_dispatch_view = search
 search = | rest /services/cluster/master/buckets `splunkadmins_clustermaster_host` \
-| search `comment("Note in larger environments this can cause an issue due to the number of peers returning data, so use with caution. The idea for this query comes from Splunk support & https://answers.splunk.com/answers/234717/how-to-get-list-of-buckets-which-are-having-issues.html , attempt to determine the count of primary buckets per peer for site0. This report is designed to provide 1 example of a useful REST endpoint")` standalone=0 frozen=0\
+| search ```Note in larger environments this can cause an issue due to the number of peers returning data, so use with caution. The idea for this query comes from Splunk support & https://answers.splunk.com/answers/234717/how-to-get-list-of-buckets-which-are-having-issues.html , attempt to determine the count of primary buckets per peer for site0. This report is designed to provide 1 example of a useful REST endpoint``` standalone=0 frozen=0\
 | rename primaries_by_site.site0 AS peerGUID\
 | join type=outer peerGUID [ rest /services/cluster/master/peers `splunkadmins_clustermaster_host` \
 | fields active_* host* label title status site\
@@ -3039,7 +3039,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/saved/searches\
-| search `comment("Look over all scheduled searches and find those not specifying/narrowing down to an index, or using the index=* trick. This version is dealing with those using macros. Please ensure the SearchHeadLevel - Macro report is also enabled for this to work as expected. Attempted to use https://answers.splunk.com/answers/186698/how-can-i-expand-a-macro-definition-in-the-search.html but the intentionsparser does not work via a REST call within Splunk, only by an external call in Splunk 7...")` `splunkadmins_scheduledsearches_without_index_macro`\
+| search ```Look over all scheduled searches and find those not specifying/narrowing down to an index, or using the index=* trick. This version is dealing with those using macros. Please ensure the SearchHeadLevel - Macro report is also enabled for this to work as expected. Attempted to use https://answers.splunk.com/answers/186698/how-can-i-expand-a-macro-definition-in-the-search.html but the intentionsparser does not work via a REST call within Splunk, only by an external call in Splunk 7...``` `splunkadmins_scheduledsearches_without_index_macro`\
 | table title , description, eai:acl.app, eai:acl.owner, qualifiedSearch, next_scheduled_time \
 | search next_scheduled_time!="" \
 | regex qualifiedSearch!=".*index\s*(!?)=\s*([^*]|\*\S+)" \
@@ -3079,12 +3079,12 @@ schedule_window = 30
 search = | rest "/servicesNS/-/-/configs/conf-macros?count=-1" `splunkadmins_restmacro` \
 | search eai:acl.sharing!="user"\
 | rename eai:acl.sharing AS sharing\
-| search `comment("Potentially having an additional field for server group would add another level of accuracy to the lookup however in this env the chance of macros with the seame name but different definitions is low enough that this might be a waste of time...")`\
+| search ```Potentially having an additional field for server group would add another level of accuracy to the lookup however in this env the chance of macros with the seame name but different definitions is low enough that this might be a waste of time...```\
 | rename eai:acl.app AS app\
 | fields title, app, definition, sharing\
 | eval splunk_server=`splunkadmins_splunk_server_name` \
-| search `comment("At this point you can add in remote search heads for macros by using the macro (with backticks) | append [ <backtick>AuditLogsMacroReport_Helper(\"<your remote host>\", \"remote_user\", \"remote_password\")<backtick> | splunk_server=... ]")`\
-| search `comment("The lookup is going to use the first value it sees, so just dedup on app/title")`\
+| search ```At this point you can add in remote search heads for macros by using the macro (with backticks) | append [ <backtick>AuditLogsMacroReport_Helper(\"<your remote host>\", \"remote_user\", \"remote_password\")<backtick> | splunk_server=... ]```\
+| search ```The lookup is going to use the first value it sees, so just dedup on app/title```\
 | eval app=if(sharing=="global","global",'app')\
 | stats first(definition) AS definition, values(sharing) AS sharing by title, app, splunk_server\
 | outputlookup splunkadmins_macros
@@ -3108,7 +3108,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to find where there are deleted roles assigned to users, this should only happen when the user was created with the Splunk authentication system. The fix is to open the user in the settings menu and find any user with the mentioned role, and then to save the user with no changes, this will wipe the non-existent roles from the user")`\
+search = ```Attempt to find where there are deleted roles assigned to users, this should only happen when the user was created with the Splunk authentication system. The fix is to open the user in the settings menu and find any user with the mentioned role, and then to save the user with no changes, this will wipe the non-existent roles from the user```\
 index=_internal sourcetype=splunkd `splunkenterprisehosts` `splunkadmins_splunkd_source` AuthorizationManager "Unknown role"\
 | eval message=coalesce(message,event_message)\
 | stats max(_time) AS lastSeen, first(_raw) AS rawMessage by message\
@@ -3140,7 +3140,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect if data is been sent to the indexers to an index which is not yet configured")`\
+search = ```Detect if data is been sent to the indexers to an index which is not yet configured```\
 index=_internal "Received event for unconfigured" sourcetype=splunkd `splunkadmins_splunkd_source` IndexerService "Received event for unconfigured" `indexerhosts`\
 | rex "index=(?P<index>[^ ]+).*source=\"source::(?P<source>[^\"]+)\" host=\"host::(?P<host>[^\"]+)"\
 | eval message=coalesce(message,event_message)\
@@ -3168,23 +3168,23 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/saved/searches `splunkadmins_restmacro` \
 | fields title, eai:acl.sharing, eai:acl.perms.read, eai:acl.perms.write, description, disabled, eai:acl.owner, dispatchAs, eai:acl.app \
-| search `comment("Find alerts that the owner is set to a user (not nobody), and the sharing is non-private, and finally the owner has an admin or power role")` eai:acl.owner!="nobody" eai:acl.sharing!="user" dispatchAs=owner \
+| search ```Find alerts that the owner is set to a user (not nobody), and the sharing is non-private, and finally the owner has an admin or power role``` eai:acl.owner!="nobody" eai:acl.sharing!="user" dispatchAs=owner \
     [| rest /services/authentication/users `searchheadsplunkservers` \
     | search roles=admin OR roles=power \
     | fields title \
     | rename title AS eai:acl.owner] \
 | eval writeCount=mvcount('eai:acl.perms.write') \
 | eval writePerms=mvjoin('eai:acl.perms.write', ",") \
-| search `comment("Exclude by macro")` `splunkadmins_privilegedowners` \
-| search `comment("If only the admin or power role can write to the alert then it's no problem...")` NOT (writeCount=1 (eai:acl.perms.write="admin" OR eai:acl.perms.write="power")) \
-| search `comment("power users have admin-like abilities, these users have a similar level of read access so less of a security concern...")` writePerms!="admin,power" \
-| search `comment("If the alert is coming from an application that only admins can see to I'm not concerned as the user should not be able to access the app to edit the search...(in theory). We also ignore if there are no read permissions at all...")` \
+| search ```Exclude by macro``` `splunkadmins_privilegedowners` \
+| search ```If only the admin or power role can write to the alert then it's no problem...``` NOT (writeCount=1 (eai:acl.perms.write="admin" OR eai:acl.perms.write="power")) \
+| search ```power users have admin-like abilities, these users have a similar level of read access so less of a security concern...``` writePerms!="admin,power" \
+| search ```If the alert is coming from an application that only admins can see to I'm not concerned as the user should not be able to access the app to edit the search...(in theory). We also ignore if there are no read permissions at all...``` \
     NOT ( \
     [| rest /services/apps/local `splunkadmins_restmacro` \
     | fields title, visible, eai:acl.perms.read \
-    | search `comment("If we cannot access the application then I'm assuming making it visible does not matter...")` visible=1 \
+    | search ```If we cannot access the application then I'm assuming making it visible does not matter...``` visible=1 \
     | eval readCount=mvcount('eai:acl.perms.read') \
-    | search `comment("If the application can only be written to by admin or power users, then we can safely ignore the alerts within it...")` (readCount=1 (eai:acl.perms.read="admin" OR eai:acl.perms.read="power") ) \
+    | search ```If the application can only be written to by admin or power users, then we can safely ignore the alerts within it...``` (readCount=1 (eai:acl.perms.read="admin" OR eai:acl.perms.read="power") ) \
     | fields title \
     | rename title AS eai:acl.app]) \
 | where isnotnull('eai:acl.perms.write') \
@@ -3211,10 +3211,10 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to detect search failures of interest, such as Search Factory: Unknown search command 'base64' so they can be fixed before it becomes an issue for multiple users. The search is generic to attempt to detect any new errors. Note that if you are running a modern Splunk version you may wish to use \"SearchHeadLevel - Search Messages admins only\" and \"SearchHeadLevel - Search Messages user level\" instead as they detect the issues at SH level")`\
+search = ```Attempt to detect search failures of interest, such as Search Factory: Unknown search command 'base64' so they can be fixed before it becomes an issue for multiple users. The search is generic to attempt to detect any new errors. Note that if you are running a modern Splunk version you may wish to use \"SearchHeadLevel - Search Messages admins only\" and \"SearchHeadLevel - Search Messages user level\" instead as they detect the issues at SH level```\
 index=_internal `indexerhosts` sourcetype=splunkd_remote_searches "ERROR" OR "WARN" NOT "remote_metrics.json does not exist before reading" NOT ", Broken pipe" NOT ", Connection closed by peer" NOT ", Connection reset by peer" NOT "is already running" NOT "Local side shutting down" NOT ("ERROR StreamedSearch" "Success") \
 | regex "\+0000 (ERROR|WARN)" \
-| search `comment("Allow exclusions via macro...")` `splunkadmins_searchfailures`\
+| search ```Allow exclusions via macro...``` `splunkadmins_searchfailures`\
 | cluster field=sid showcount=true \
 | table host, cluster_count, _raw \
 | eval indexer_cluster=`indexer_cluster_name(host)` 
@@ -3239,14 +3239,14 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/data/ui/views `splunkadmins_restmacro`\
-| search `comment("A dashboard searching all indexes is an issue just like a scheduled search querying all indexes or using the index=* trick. This version is dealing with those using macros. Please ensure the SearchHeadLevel - Macro report is also enabled for this to work as expected.")` \
+| search ```A dashboard searching all indexes is an issue just like a scheduled search querying all indexes or using the index=* trick. This version is dealing with those using macros. Please ensure the SearchHeadLevel - Macro report is also enabled for this to work as expected.``` \
     eai:data=*query* NOT (eai:appName=simple_xml_examples eai:acl.sharing=app) NOT (eai:appName=nmon eai:acl.sharing=app) NOT (eai:appName=splunk_app_aws eai:acl.sharing=app) \
 | regex eai:data="<search.*" \
 | mvexpand theSearch \
 | rex field=eai:data "(?s)(?P<theSearch><search(?!String)[^>]*>[^<]*<query>.*?)<\/query>" max_match=200 \
 | mvexpand theSearch \
 | rex field=theSearch "(?s)<search(?P<searchInfo>[^>]*)>[^<]*<query>(?P<theQuery>.*)" \
-| search `comment("If we are seeing post process search then we don't want to check if it has index= because that is likely only in the base query. These are also various exclusions for legitimate searches that will not involve scanning all indexes, such as rest or a savedsearch or similar")` searchInfo!="*base*" \
+| search ```If we are seeing post process search then we don't want to check if it has index= because that is likely only in the base query. These are also various exclusions for legitimate searches that will not involve scanning all indexes, such as rest or a savedsearch or similar``` searchInfo!="*base*" \
 | rename eai:appName AS application, eai:acl.sharing AS sharing, eai:acl.owner AS identity, label AS name \
 | table theQuery, application, identity, sharing, name, splunk_server, title \
 | regex theQuery!="index\s*=(?!\s*\*)" \
@@ -3281,7 +3281,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = index=_internal `searchheadhosts` sourcetype=splunkd `splunkadmins_splunkd_source` "SHCRaftConsensus" NOT "failed appendEntriesRequest err" NOT (SHCRaftConsensus "NOT_LEADER") `splunkadmins_captain_switchover`\
-| search `comment("Exclude the search head shutdown times")` NOT [`splunkadmins_shutdown_time(searchheadhosts,20,120)`] `comment("Exclude manual transfer")` NOT [`splunkadmins_transfer_captain_times(searchheadhosts,20,120)`]\
+| search ```Exclude the search head shutdown times``` NOT [`splunkadmins_shutdown_time(searchheadhosts,20,120)`] ```Exclude manual transfer``` NOT [`splunkadmins_transfer_captain_times(searchheadhosts,20,120)`]\
 | cluster showcount=true\
 | fields _time, cluster_count, _raw\
 | sort - _time
@@ -3305,15 +3305,15 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to find entries in the splunkd logs that indiciate that Splunk is resource constrained and requires more CPU or similar")`\
-index=_internal `indexerhosts`  sourcetype=splunkd `splunkadmins_splunkd_source` "Might indicate hardware or splunk limitations" OR "took longer than" `comment("This is useful for reporting but not so useful for alerting... OR \"WARN  PeriodicReapingTimeout\"")` NOT "Might indicate slow ldap server." `comment("Add in OR (WARN ConfMetrics) ?)")` \
+search = ```Attempt to find entries in the splunkd logs that indiciate that Splunk is resource constrained and requires more CPU or similar```\
+index=_internal `indexerhosts`  sourcetype=splunkd `splunkadmins_splunkd_source` "Might indicate hardware or splunk limitations" OR "took longer than" ```This is useful for reporting but not so useful for alerting... OR \"WARN  PeriodicReapingTimeout\"``` NOT "Might indicate slow ldap server." ```Add in OR (WARN ConfMetrics) ?)``` \
 | rex "^[\d-]+ [\d:\.]+( )+[\+-]?\d+( )+[^ ]+( )+(?P<componentAndArea>([^ ]+( )+){3}).*\((?P<number>\d+) milliseconds" \
 | rex "^[\d-]+ [\d:\.]+( )+[\+-]?\d+( )+[^ ]+( )+(?P<componentAndArea2>DispatchManager\s+([^ ]+( )+){3}).*elapsed_ms=(?P<number3>\d+)" \
 | rex "Spent (?P<number2>\d+)"\
 | rex "reaping (?P<area>([^ ]+ ){2})"\
 | eval componentAndArea=case(isnotnull(componentAndArea2),componentAndArea2,isnull(componentAndArea),component . "_" . area,1=1,componentAndArea), number=coalesce(number,number2,number3)\
 | stats count, avg(number) AS avgTimeInSeconds, max(number) AS maxTimeInSeconds, max(_time) AS mostRecent, min(_time) AS firstSeen by componentAndArea, host\
-| search `comment("Allow custom exclusions")` `splunkadmins_resource_starvation`\
+| search ```Allow custom exclusions``` `splunkadmins_resource_starvation`\
 | sort - mostRecent\
 | eval firstSeen=strftime(firstSeen, "%+"), mostRecent=strftime(mostRecent, "%+"), avgTimeInSeconds=round(avgTimeInSeconds/1000,2), maxTimeInSeconds=round(maxTimeInSeconds/1000,2)
 disabled = 1
@@ -3336,14 +3336,14 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("An attempt to detect excessive numbers of S2SFileReceiver / TcpInputProc failures on the indexing tier, these may indicate an issue. We are only looking for errors about replication data")`\
-`comment("An indexer peer that was constantly logging \"S2SFileReceiver...type=data_model already exists!\" / \"S2SFileReceiver...type=report_acceleration already exists!\" has been fixed by restart (once so far)")`\
+search = ```An attempt to detect excessive numbers of S2SFileReceiver / TcpInputProc failures on the indexing tier, these may indicate an issue. We are only looking for errors about replication data```\
+```An indexer peer that was constantly logging \"S2SFileReceiver...type=data_model already exists!\" / \"S2SFileReceiver...type=report_acceleration already exists!\" has been fixed by restart (once so far)```\
 index=_internal sourcetype=splunkd `indexerhosts` sourcetype=splunkd `splunkadmins_splunkd_source` ("ERROR TcpInputProc" "event=replicationData") OR ("ERROR S2SFileReceiver" "error alerting slave about") OR ("ERROR S2SFileReceiver" "error adding new summary replica to slave")\
 | rex "(?P<error>ERROR [^-]+- [^=]+=)(?P<postEquals>[^ ]+) (?P<postEquals2>[^=]+=[^ ]+)"\
 | rex field=err "(?P<type>type=.*)"\
 | eval error=if(postEquals=="onFileAborted" OR postEquals=="replicationData",error . " " . postEquals . " " . postEquals2,error . " " . type)\
 | stats count, max(_time) AS mostRecent by host, error\
-| search `comment("Allow exclusion via macro")` `splunkadmins_s2sfilereceiver`\
+| search ```Allow exclusion via macro``` `splunkadmins_s2sfilereceiver`\
 | eval mostRecent=strftime(mostRecent, "%+")
 disabled = 1
 
@@ -3374,9 +3374,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins 
 request.ui_dispatch_view = search
-search = `comment("Attempt to detect when a Splunk scripted_input appears to be running at OS level even though disabled=1 is set")`\
-`comment("Splunk support have advised that the modular input scripts run by design, in fact disabled=1 means the inheriting input stanzas should be disabled, not that the modular input is disabled")`\
-`comment("As per the updated documentation on https://docs.splunk.com/Documentation/AddOns/released/Overview/Distributedinstall best practice is now to remove the inputs.conf and inputs.conf.spec on SH clusters...")`\
+search = ```Attempt to detect when a Splunk scripted_input appears to be running at OS level even though disabled=1 is set```\
+```Splunk support have advised that the modular input scripts run by design, in fact disabled=1 means the inheriting input stanzas should be disabled, not that the modular input is disabled```\
+```As per the updated documentation on https://docs.splunk.com/Documentation/AddOns/released/Overview/Distributedinstall best practice is now to remove the inputs.conf and inputs.conf.spec on SH clusters...```\
 index=_introspection `localsearchheadhosts` sourcetype=splunk_resource_usage \
 | spath component \
 | search component=PerProcess data.process!=splunkd \
@@ -3404,8 +3404,8 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect forwarders stuck connecting to a single indexer or heavy forwarder for an extended period of time...Assuming more than 60 seconds of continuous traffic is a problem...this may need to be customised for your environment")`\
-`comment("Note that the number of metrics defaults to the top 10 measured every 30 seconds, so if this is customised you will need to change this alert")`\
+search = ```Detect forwarders stuck connecting to a single indexer or heavy forwarder for an extended period of time...Assuming more than 60 seconds of continuous traffic is a problem...this may need to be customised for your environment```\
+```Note that the number of metrics defaults to the top 10 measured every 30 seconds, so if this is customised you will need to change this alert```\
 index=_internal sourcetype=splunkd `splunkadmins_metrics_source` sourcetype=splunkd group=tcpin_connections Metrics `indexerhosts` OR `heavyforwarderhosts`\
 | eval ingest_pipe = if(isnotnull(ingest_pipe), ingest_pipe, "none")\
 | streamstats time_window=60s count by hostname, host, ingest_pipe\
@@ -3425,8 +3425,8 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect forwarders stuck connecting to a single indexer or heavy forwarder for an extended period of time...Assuming more than 60 seconds of continuous traffic is a problem...this may need to be customised for your environment")`\
-`comment("Note that the number of metrics defaults to the top 10 measured every 30 seconds, so if this is customised you will need to change this alert")`\
+search = ```Detect forwarders stuck connecting to a single indexer or heavy forwarder for an extended period of time...Assuming more than 60 seconds of continuous traffic is a problem...this may need to be customised for your environment```\
+```Note that the number of metrics defaults to the top 10 measured every 30 seconds, so if this is customised you will need to change this alert```\
 index=_internal sourcetype=splunkd `splunkadmins_metrics_source` sourcetype=splunkd group=tcpin_connections Metrics `indexerhosts` OR `heavyforwarderhosts`\
 | eval ingest_pipe = if(isnotnull(ingest_pipe), ingest_pipe, "none")\
 | streamstats time_window=60s count by name, host, ingest_pipe\
@@ -3446,7 +3446,7 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Determine the query scan density of queries per-index. Excludes replicated search jobs (rsa)")` index=_audit `searchheadhosts` action=search sourcetype=audittrail search_id!="rsa_*"\
+search = ```Determine the query scan density of queries per-index. Excludes replicated search jobs (rsa)``` index=_audit `searchheadhosts` action=search sourcetype=audittrail search_id!="rsa_*"\
 | eval sname=if(isnull(savedsearch_name) OR savedsearch_name=="", search, savedsearch_name)\
 | stats list(search_type) as search_type, list(api_et) as api_et, list(api_lt) as api_lt, list(apiStartTime) as apiStartTime, list(apiEndTime) as apiEndTime,list(search_et) as search_et, list(search_lt) as search_lt, list(info) as status, list(total_run_time) as total_run_time list(event_count) as event_count,list(considered_events) as considered_events, list(result_count) as result_count, list(scan_count) as scan_count, list(ttl) as ttl, list(is_realtime) as search_realtime_check, list(_time) as TimeAudited, list(sname) as sname by search_id\
 | where isnotnull(scan_count) AND NOT event_count="N/A" AND LIKE(sname, "%index%=%")\
@@ -3467,9 +3467,9 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("For the alert version of this report refer to IndexerLevel - Unclean Shutdown - Fsck, you may also wish to try IndexerLevel - Corrupt buckets via DBInspect")`\
-`comment("Attempt to find bucket corruption errors in the splunkd logs. this can also be found at search head level via the info.csv (not indexed by default). In a clustered environment a message such as \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds\" may appear once the auto-repair has occurred. Finally it may appear if log_search_messages is set in limits.conf (enabled by default in 9.1 and above), the sourcetype will be splunk_search_messages")`\
-index=_internal `indexerhosts` sourcetype=splunkd `splunkadmins_splunkd_source` IndexerService OR HotBucketRoller "corrupt" newly `comment("newly appears to show corruption, previously may be the term for when it is fixed...")`\
+search = ```For the alert version of this report refer to IndexerLevel - Unclean Shutdown - Fsck, you may also wish to try IndexerLevel - Corrupt buckets via DBInspect```\
+```Attempt to find bucket corruption errors in the splunkd logs. this can also be found at search head level via the info.csv (not indexed by default). In a clustered environment a message such as \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds\" may appear once the auto-repair has occurred. Finally it may appear if log_search_messages is set in limits.conf (enabled by default in 9.1 and above), the sourcetype will be splunk_search_messages```\
+index=_internal `indexerhosts` sourcetype=splunkd `splunkadmins_splunkd_source` IndexerService OR HotBucketRoller "corrupt" newly ```newly appears to show corruption, previously may be the term for when it is fixed...```\
 | stats values(Bucket) AS bucketList by idx \
 | eval bucketCount=mvcount(bucketList)\
 | addcoltotals
@@ -3494,9 +3494,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Further testing required. Detect failures from the search.log advising that the peer was unable to send a response, for example This can be caused by the peer unexpectedly closing or resetting the connection. Search results might be incomplete!...This requires the search.log messages (see description of this alert) to obtain the splunk_search_messages sourcetype. The Unable to distribute to peer named status=Down scenario can also result from having many indexers and may require an increase to the timeouts in distsearch.conf")`\
-`comment("info.csv often reports failures as well but sometimes these are not in search.log and vice-versa. Unable to distribute to peer/Connection failed/Unable to determine response all appear to be some kind of failure. Attempting to use the [search] log_search_messages = true in the limits.conf file and then use the search_messages.log file to find what would normally appear in info.csv in the dispatch directory per-search...Note this is enabled by default in 9.1 and above")`\
-index=_internal sourcetype=splunk_server_messages source!="*rsa_scheduler_*" `searchheadhosts` ("error" "for peer") OR "Error connecting" OR "Got status" `comment("Ignoring \"HTTP error status message from\" OR \"HTTP client error\" as they tend to appear when one of the previous examples is there...")`\
+search = ```Further testing required. Detect failures from the search.log advising that the peer was unable to send a response, for example This can be caused by the peer unexpectedly closing or resetting the connection. Search results might be incomplete!...This requires the search.log messages (see description of this alert) to obtain the splunk_search_messages sourcetype. The Unable to distribute to peer named status=Down scenario can also result from having many indexers and may require an increase to the timeouts in distsearch.conf```\
+```info.csv often reports failures as well but sometimes these are not in search.log and vice-versa. Unable to distribute to peer/Connection failed/Unable to determine response all appear to be some kind of failure. Attempting to use the [search] log_search_messages = true in the limits.conf file and then use the search_messages.log file to find what would normally appear in info.csv in the dispatch directory per-search...Note this is enabled by default in 9.1 and above```\
+index=_internal sourcetype=splunk_server_messages source!="*rsa_scheduler_*" `searchheadhosts` ("error" "for peer") OR "Error connecting" OR "Got status" ```Ignoring \"HTTP error status message from\" OR \"HTTP client error\" as they tend to appear when one of the previous examples is there...```\
 | rex "for peer (?P<peer>[^\.]+)"\
 | rex "ERROR\s+\S+\s+-\s+(sid:[^ ]+)?(?P<message>.*)"\
 | bin _time span=1m\
@@ -3534,9 +3534,9 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Note this requires further testing due to switch to splunk_search_messages")`\
-`comment("Attempt to find corrupt buckets appearing in the search heads dispatch/info.csv files, this will show that a user is seeing the \"data may be corrupt\" messages")`\
-`comment("In a clustered environment this should auto-repair via the cluster master fixup list, messages such as \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds.\" should appear in the splunkd logs. In a non-clustered environment refer to the Splunk fsck documentation. You may also wish to try IndexerLevel - Corrupt buckets via DBInspect")`\
+search = ```Note this requires further testing due to switch to splunk_search_messages```\
+```Attempt to find corrupt buckets appearing in the search heads dispatch/info.csv files, this will show that a user is seeing the \"data may be corrupt\" messages```\
+```In a clustered environment this should auto-repair via the cluster master fixup list, messages such as \"06-12-2018 07:31:47.160 +0000 INFO  ProcessTracker - (child_407__Fsck)  Fsck - (entire bucket) Rebuild for bucket='/opt/splunk/var/lib/splunk/indexname/db/db_1528466340_1520517600_38_A25ECA32-B33E-4469-8C76-22190FDCC8CB' took 86.26 seconds.\" should appear in the splunkd logs. In a non-clustered environment refer to the Splunk fsck documentation. You may also wish to try IndexerLevel - Corrupt buckets via DBInspect```\
 index=_internal sourcetype=splunk_search_messages "corrupt" OR "corrupted" OR "Consider running fsck" `searchheadhosts` \
 | rex ",\"(\[[^\]]+\]\[[^\]]+\]: )?\[(?P<peer>[^\]]+)"\
 | rex "message=\[(?P<peer>[^\]]+)" \
@@ -3563,21 +3563,21 @@ display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 schedule_window = 30
-search = `comment("The listed users have reached the maximum disk quota, they may be unaware so it is best to let them know about this issue...")`\
-`comment("Note that the REST API call accesses the jobs list which can expire for ad-hoc jobs in 10 minutes, the introspection index has data for a longer period of time however it's not as accurate as the rest version. This alert also outputs the emailed users to a lookup so they don't continue to receive this same email without some kind of throttle per-user")`\
-`comment("The REST version is called SearchHeadLevel - Users exceeding the disk quota and is search head specific")`\
+search = ```The listed users have reached the maximum disk quota, they may be unaware so it is best to let them know about this issue...```\
+```Note that the REST API call accesses the jobs list which can expire for ad-hoc jobs in 10 minutes, the introspection index has data for a longer period of time however it's not as accurate as the rest version. This alert also outputs the emailed users to a lookup so they don't continue to receive this same email without some kind of throttle per-user```\
+```The REST version is called SearchHeadLevel - Users exceeding the disk quota and is search head specific```\
 index=_internal sourcetype=splunkd `splunkenterprisehosts` (`splunkadmins_splunkd_source`) "maximum disk usage quota" `splunkadmins_users_exceeding_diskquota` NOT [| inputlookup splunkusersexceedingdiskquota.csv | fields username ]\
 | stats max(_time) AS mostRecent by username, reason, host\
 | rename username AS username_from_search\
 | eval mostRecent = strftime(mostRecent, "%+")\
-| search `comment("For each result we find we're going to run the map command to send an email to each individual user who has had the issue, if they have been emailed before the inputlookup will exclude them. Username renamed due to issues with username variable in a scheduled search")`\
+| search ```For each result we find we're going to run the map command to send an email to each individual user who has had the issue, if they have been emailed before the inputlookup will exclude them. Username renamed due to issues with username variable in a scheduled search```\
 | eval body="Why am I receiving this? <br />" + reason + "<br /><br /> This occurred on host " + host + "<br /><br />The issue was last noticed on " + mostRecent + "<br /><br />" + "Your top 20 searches are listed below" + "<br /><br />"\
-| search `comment("The below is the attempt to include the largest jobs by querying the introspection index. If we use map without the appendpipe we lose parts of the original search we need. The initial workaround of makeresults and eval commands did work but this seemed slightly cleaner. Although there would be other ways to do this...")`\
+| search ```The below is the attempt to include the largest jobs by querying the introspection index. If we use map without the appendpipe we lose parts of the original search we need. The initial workaround of makeresults and eval commands did work but this seemed slightly cleaner. Although there would be other ways to do this...```\
 | head 30\
 | append [ | makeresults | eval username_from_search="workaround for map errors", body="to pass appinspect" ]\
 | appendpipe\
     [| map\
-        [ search `comment("The intropsection data provides a written_mb field which is not going to advise an accurate real-disk usage for a job, but it does provide an estimate and provides data for longer than a 10 minute time period for ad-hoc jobs...the | rest version is the alternative available which is more accurate but may return zero results if this is not run at least every 10 minutes, it also must run on the same search head cluster as the disk usage quota, unlike this introspection version. max(data.written_mb) was used instead of last() as sometimes the quota kicks in before the temporary files are removed.")`\
+        [ search ```The intropsection data provides a written_mb field which is not going to advise an accurate real-disk usage for a job, but it does provide an estimate and provides data for longer than a 10 minute time period for ad-hoc jobs...the | rest version is the alternative available which is more accurate but may return zero results if this is not run at least every 10 minutes, it also must run on the same search head cluster as the disk usage quota, unlike this introspection version. max(data.written_mb) was used instead of last() as sometimes the quota kicks in before the temporary files are removed.```\
             index=_introspection "data.search_props.role"=head data.written_mb>1 sourcetype=splunk_resource_usage "data.search_props.user"=$username_from_search$\
         | stats max(data.written_mb) AS MBwritten, last(data.elapsed) AS approxDuration, max(_time) AS searchLatestTime, min(_time) AS searchEarliestTime by "data.search_props.app", "data.search_props.provenance", "data.search_props.type", "data.search_props.sid"\
         | stats count, sum(MBwritten) AS MBwritten, max(approxDuration) AS approxDuration, max(searchLatestTime) AS searchLatestTime, min(searchEarliestTime) AS searchEarliestTime by "data.search_props.app", "data.search_props.provenance", "data.search_props.type"\
@@ -3586,10 +3586,10 @@ index=_internal sourcetype=splunkd `splunkenterprisehosts` (`splunkadmins_splunk
         | sort - MBwritten\
         | eval approxDuration=substr(tostring(approxDuration,"duration"),0,8)\
         | appendcols\
-            [ search `comment("At this point you need to either lookup the username to email translation, here's an example using ldapsearch: ldapsearch search=\"(&(CN=$username_from_search$)(objectClass=organizationalPerson))\" attrs=mail | fields mail")` ]\
+            [ search ```At this point you need to either lookup the username to email translation, here's an example using ldapsearch: ldapsearch search=\"(&(CN=$username_from_search$)(objectClass=organizationalPerson))\" attrs=mail | fields mail``` ]\
         | eval email_to=mail\
         | fields - mail\
-        | search `comment('Remove search/comment and replace <EQ> with equals to use sendresults to make this fully automated. AppInspect badge does not allow dependencies. sendresults subject<EQ>"Splunk Disk Quota Exceeded" body<EQ>$body$ msgstyle<EQ>"table {font-family:Arial;font-size:12px;border: 1px solid black;padding:3px}th {background-color:#AAAAAA;color:#fff;border-left: solid 1px #e9e9e9} td {border:solid 1px #e9e9e9}" showemail<EQ>f')`\
+        | search ```'Remove search/comment and replace <EQ> with equals to use sendresults to make this fully automated. AppInspect badge does not allow dependencies. sendresults subject<EQ>"Splunk Disk Quota Exceeded" body<EQ>$body$ msgstyle<EQ>"table {font-family:Arial;font-size:12px;border: 1px solid black;padding:3px}th {background-color:#AAAAAA;color:#fff;border-left: solid 1px #e9e9e9} td {border:solid 1px #e9e9e9}" showemail<EQ>f'```\
         | head 20 ] maxsearches=30\
         ]\
 | where username_from_search!="workaround for map errors"\
@@ -3636,7 +3636,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("As found on https://runals.blogspot.com/2014/05/splunk-dateparserverbose-logs-part-2.html with minor modifications. Further queries available in the app https://splunkbase.splunk.com/app/1848/")`\
+search = ```As found on https://runals.blogspot.com/2014/05/splunk-dateparserverbose-logs-part-2.html with minor modifications. Further queries available in the app https://splunkbase.splunk.com/app/1848/```\
 index=_internal DateParserVerbose `heavyforwarderhosts` OR `indexerhosts` sourcetype=splunkd `splunkadmins_splunkd_source`\
 | rex "source(?:=|::)(?<Source>[^\|]+)\|host(?:=|::)(?<Host>[^\|]+)\|(?<Sourcetype>[^\|]+)"\
 | rex "(?<msgs_suppressed>\d+) similar messages suppressed."\
@@ -3659,7 +3659,7 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Query the audit logs for information about earliest/latest time and the search used. However the issue appears to be that apiStart/EndTime can be overriden by earliest/latest keywords *and* the auto-extracted search field isn't accurate and savedsearch_name of search<number> is actually a dashboards (which can be seen through introspection but not through audit searches!")`\
+search = ```Query the audit logs for information about earliest/latest time and the search used. However the issue appears to be that apiStart/EndTime can be overriden by earliest/latest keywords *and* the auto-extracted search field isn't accurate and savedsearch_name of search<number> is actually a dashboards (which can be seen through introspection but not through audit searches!```\
 index=_audit `searchheadhosts` action=search info=granted search=* NOT "search='typeahead prefix"\
 | rex "(?m)search='(?P<thesearch>[\S\s]+)',\s+autojoin="\
 | table _time, ttl, user, apiStartTime, apiEndTime, earliest, latest, savedsearch_name, thesearch\
@@ -3676,9 +3676,9 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("May not be 100% accurate, still under testing. deleteBucket frozen=false is usually excess bucket removal")`\
+search = ```May not be 100% accurate, still under testing. deleteBucket frozen=false is usually excess bucket removal```\
 index=_internal "Creating hot bucket" OR ((CMSlave deleteBucket) AND "frozen=false") OR "freeze succeeded" sourcetype=splunkd `splunkadmins_splunkd_source` `indexerhosts`\
-`comment("Multiplying by replication factor as each hot bucket is duplicated")`\
+```Multiplying by replication factor as each hot bucket is duplicated```\
 `comment("To split by index\
 | rex "(/[^/]+){2}/(?P<idx2>[^/]+)"\
 | eval idx=if(isnull(idx),idx2,idx)\
@@ -3713,10 +3713,10 @@ display.page.search.tab = statistics
 display.visualizations.show = 0
 request.ui_dispatch_app = Global
 request.ui_dispatch_view = search
-search = `comment("Find searches which have been auto-finalized and the search contents which was running when the search was auto-finalized. Very similar to Users Exceeding the disk quota however this covers both disk quota and srchMaxTime. Note this alert requires further testing")`\
-`comment("This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1")`\
+search = ```Find searches which have been auto-finalized and the search contents which was running when the search was auto-finalized. Very similar to Users Exceeding the disk quota however this covers both disk quota and srchMaxTime. Note this alert requires further testing```\
+```This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1```\
 index=_internal `searchheadhosts` sourcetype=splunk_search_messages auto-finalized\
- `comment("for even more info...OR canceled OR auto-canceled OR cancelled")` \
+ ```for even more info...OR canceled OR auto-canceled OR cancelled``` \
 | rex field=source "[/\\\]dispatch[/\\\](?P<sid>[^/\\\]+)"\
 | rex "(?P<message>auto-finalized[^\"]+)"\
 | fillnull message value="Unknown"\
@@ -3749,7 +3749,7 @@ display.visualizations.charting.chart = line
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Count the number of non-system Splunk queries that use a search command, excludes rest/metrics/data model acceleration et cetera")`\
+search = ```Count the number of non-system Splunk queries that use a search command, excludes rest/metrics/data model acceleration et cetera```\
 index=_audit `searchheadhosts` ", info=granted " "search='search " search_id!="'SummaryDirector_*" search_id!="'rsa_*" user!=admin user!=splunk-system-user \
 | bin _time span=1d \
 | rex "info=granted , search_id='(?P<search_id>[^']+)"\
@@ -3779,7 +3779,7 @@ display.visualizations.show = 0
 display.visualizations.trellis.splitBy = _aggregation
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Based on the audit logs attempt to determine which types of searches are running and provide a rough % for each one")`\
+search = ```Based on the audit logs attempt to determine which types of searches are running and provide a rough % for each one```\
     index=_audit ", info=granted " `searchheadhosts` "search='" search_id!="'rsa_*"\
 | rex "(?s), search='(?P<search>.*)\]$" \
 | rex field=search "^(\s*\|)?(?P<searchbeforepipe>[^|]+)" \
@@ -3815,7 +3815,7 @@ display.visualizations.charting.chart = pie
 display.visualizations.trellis.splitBy = _aggregation
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Based on the audit logs attempt to determine which types of searches are running and provide a rough % for each one")`\
+search = ```Based on the audit logs attempt to determine which types of searches are running and provide a rough % for each one```\
     index=_audit `searchheadhosts` ", info=granted " "search='" search_id!="'rsa_*"\
 | rex "(?s), search='(?P<search>.*)\]$" \
 | `splunkadmins_macro_sub("search")` \
@@ -3853,7 +3853,7 @@ display.visualizations.charting.chart = pie
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Based on the audit logs attempt to determine which types of searches are running and provide a rough % for each one")`\
+search = ```Based on the audit logs attempt to determine which types of searches are running and provide a rough % for each one```\
     index=_audit `searchheadhosts` ", info=granted " "search='" search_id!="'rsa_*"\
 | rex "(?s), search='(?P<search>.*)\]$" \
 | `splunkadmins_macro_sub("search")` \
@@ -4059,8 +4059,8 @@ display.visualizations.charting.chart = area
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This likely came from a Splunk conf presentation but I cannot remember which one so cannot attribute the original author!")`\
-`comment("Determine the length of time a scheduled search takes to run compared to how often it is configured to run, excluding acceleration jobs")`\
+search = ```This likely came from a Splunk conf presentation but I cannot remember which one so cannot attribute the original author!```\
+```Determine the length of time a scheduled search takes to run compared to how often it is configured to run, excluding acceleration jobs```\
 index=_internal `searchheadhosts` sourcetype=scheduler source=*scheduler.log (user=*) savedsearch_name!="_ACCELERATE_DM*"\
 | stats avg(run_time) as average_runtime_in_sec count(savedsearch_name) as num_times_per_week sum(run_time) as total_runtime_sec by savedsearch_name user app host\
 | eval ran_every_x_mins=round(60/(num_times_per_week/168))\
@@ -4089,7 +4089,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Waiting for TcpOutputGroups to shutdown followed by the message 'Forcing TcpOutputGroups to shutdown after timeout' is not something that can be controlled as of 7.2.1. It also generally correlates with data loss as the forwarder in question could not get the data through the queues and out of the forwarder/indexer before shutdown. Increasing parsingQueue/aggQueue or similar may help in this scenario")`\
+search = ```Waiting for TcpOutputGroups to shutdown followed by the message 'Forcing TcpOutputGroups to shutdown after timeout' is not something that can be controlled as of 7.2.1. It also generally correlates with data loss as the forwarder in question could not get the data through the queues and out of the forwarder/indexer before shutdown. Increasing parsingQueue/aggQueue or similar may help in this scenario```\
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) "Forcing TcpOutputGroups to shutdown after timeout"\
 | stats count, earliest(_time) AS firstSeen, latest(_time) AS lastSeen by host \
 | eval firstSeen = strftime(firstSeen, "%+"), lastSeen=strftime(lastSeen, "%+")
@@ -4117,7 +4117,7 @@ display.visualizations.charting.chart = area
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Determine dashboard load times by using the introspection index, note that changes in the timepicker or similar will change your dashboard load times so this is provided as an example query only")`\
+search = ```Determine dashboard load times by using the introspection index, note that changes in the timepicker or similar will change your dashboard load times so this is provided as an example query only```\
 index=_introspection `searchheadhosts` sourcetype=splunk_resource_usage data.search_props.sid::* "UI:Dashboard"\
 | eval app = 'data.search_props.app'\
 | eval elapsed = 'data.elapsed'\
@@ -4158,7 +4158,7 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest /servicesNS/-/-/saved/searches `splunkadmins_restmacro`\
   | fields qualifiedSearch, next_scheduled_time, title, eai:acl.owner, eai:acl.app\
-  | search `comment("Based on the discussion with Burch on https://answers.splunk.com/answers/702075/what-is-the-best-way-to-find-searches-without-sour.html just a simple way of reporting if sourcetype/index fields are used in saved searches")`\
+  | search ```Based on the discussion with Burch on https://answers.splunk.com/answers/702075/what-is-the-best-way-to-find-searches-without-sour.html just a simple way of reporting if sourcetype/index fields are used in saved searches```\
   | where match( qualifiedSearch , "^\s*search\s*" )\
   | rex field=qualifiedSearch "(?s)^(?<base_search>search[^\|\[]+)"\
   | eval\
@@ -4185,14 +4185,14 @@ display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins 
 request.ui_dispatch_view = search
 description = Report only? Yes. Attempt to determine what times knowledge object config was changed by using splunk access logs (information not available in audit logs at the time of testing). Also refer to SearchHeadLevel - Detect changes to knowledge objects directory/non-directory 
-search = `comment("Attempt to determine what changes to knowledge or creation of new knowledge objects on a per-application/type basis. Using splunkd*access logs due to lack of information in other logs in non-clustered search heads. Everything works fine unless the /services/ endpoint is used in which case we have no idea which app owned the updated item and we have to just assume it could be any app. Also the query is super-complicated because Splunk often provides 3 endpoints to edit the same config, it also allows // or similar in the URL. Also refer to the alternative queries for SearchHeadLevel - Detect changes to knowledge objects directory, and SearchHeadLevel - Detect changes to knowledge objects non-directory")`\
+search = ```Attempt to determine what changes to knowledge or creation of new knowledge objects on a per-application/type basis. Using splunkd*access logs due to lack of information in other logs in non-clustered search heads. Everything works fine unless the /services/ endpoint is used in which case we have no idea which app owned the updated item and we have to just assume it could be any app. Also the query is super-complicated because Splunk often provides 3 endpoints to edit the same config, it also allows // or similar in the URL. Also refer to the alternative queries for SearchHeadLevel - Detect changes to knowledge objects directory, and SearchHeadLevel - Detect changes to knowledge objects non-directory```\
 index=_internal sourcetype=splunkd_access OR sourcetype=splunkd_ui_access method=POST status=200 OR status=201 NOT "/manager/" NOT "/dispatch HTTP"\
 | rex field=uri "/servicesNS/[^/]+/(?P<app>[^/]+)" \
 | eval type=case(match(uri,"/data/+props/+calcfields($|/)"),"calcfields",match(uri,"/saved/+searches($|/)"),"savedsearch",match(uri,"/admin/+savedsearch($|/)"),"savedsearch",match(uri,"/configs/+conf-savedsearches"),"savedsearch",match(uri,"/data/+ui/+views($|/)"),"dashboards",match(uri,"/+admin/+views($|/)"),"dashboards",match(uri,"/data/+props/+fieldaliases($|/)"),"fieldaliases",match(uri,"/+admin/+fieldaliases(/|$)"),"fieldaliases",match(uri,"data/+props/+extractions"),"fieldextractions",match(uri,"/+admin/+props-extract($|/)"),"fieldextractions",match(uri,"/data/+transforms/+extractions($|/)"),"fieldtransformations",match(uri,"/+admin/+transforms-extract($|/)"),"fieldtransformations",match(uri,"data/+ui/+workflow-actions($|/)"),"workflow-actions",match(uri,"/+admin/+workflow-actions($|/)"),"workflow-actions",match(uri,"/+configs/+conf-workflow_actions($|/)"),"workflow-actions",match(uri,"/+configs/+conf-props($|/)"),"props*",match(uri,"/+configs/+conf-transforms($|/)"),"transforms*",match(uri,"/+data/+props/+sourcetype-rename($|/)"),"sourcetype-renaming",match(uri,"/+admin/+sourcetype-rename($|/)"),"sourcetype-renaming",match(uri,"/+admin/+tags($|/)"),"tags",match(uri,"/+saved/+(n|fv)tags($|/)"),"tags",match(uri,"/+configs/+conf-tags($|/)"),"tags",match(uri,"/+saved/+eventtypes($|/)"),"eventtypes",match(uri,"/+admin/+eventtypes($|/)"),"eventtypes",match(uri,"/+configs/+conf-eventtypes($|/)"),"eventtypes_conf",match(uri,"/+data/+ui/+nav($|/)"),"navMenu",match(uri,"/+admin/*nav($|/)"),"navMenu",match(uri,"/+datamodel/+model($|/)"),"datamodel",match(uri,"/+configs/+conf-datamodels($|/)"),"datamodel",match(uri,"/+admin/+datamodel-files($|/)"),"datamodel",match(uri,"/+admin/+datamodeledit($|/)"),"datamodel",match(uri,"/+storage/+collections/+config($|/)"),"kvstore",match(uri,"/+configs/+conf-collections($|/)"),"kvstore",match(uri,"/+admin/+collections-conf($|/)"),"kvstore",match(uri,"/+data/+ui/+times($|/)"),"times",match(uri,"/+configs/+conf-times($|/)"),"times",match(uri,"/+admin/+conf-times($|/)"),"times",match(uri,"/+data/+ui/+panels($|/)"),"panels",match(uri,"/+configs/+conf-panels($|/)"),"panels",match(uri,"/+data/+props/+lookups($|/)"),"lookup-definition",match(uri,"/+admin/+props-lookup($|/)"),"lookup-definition",match(uri,"/+data/+transforms/+lookups($|/)"),"automaticlookup",match(uri,"/+admin/+transforms-lookup($|/)"),"automaticlookup",match(uri,"/+admin/+macros($|/)"),"macros",match(uri,"/+configs/+conf-macros($|/)"),"macros",match(uri,"/+data/+macros($|/)"),"macros",1==1,"unknown")\
 | where type!="unknown"\
 | eval app=if(isnull(app),"*",app)\
 | eval type2 = if(type=="eventtypes","tags",null())\
-| search `comment("note that eventtypes can have tags created so assume eventtype == tag creation, eventtypes_conf doesn't appear to work")`\
+| search ```note that eventtypes can have tags created so assume eventtype == tag creation, eventtypes_conf doesn't appear to work```\
 | stats values(_time) AS times, values(user) AS userList, values(type2) AS type2 by type, app
 
 [SearchHeadLevel - Detect changes to knowledge objects directory]
@@ -4265,7 +4265,7 @@ display.visualizations.show = 0
 description = Report only? Yes. As found on SplunkAnswers check the maximum memory usage per-search ( https://answers.splunk.com/answers/500973/how-to-improve-my-search-to-identify-queries-which.html ) 
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("As originally found on https://answers.splunk.com/answers/500973/how-to-improve-my-search-to-identify-queries-which.html / DalJeanis with minor modifications. Max memory used per search process at search head level")`\
+search = ```As originally found on https://answers.splunk.com/answers/500973/how-to-improve-my-search-to-identify-queries-which.html / DalJeanis with minor modifications. Max memory used per search process at search head level```\
 index=_introspection `searchheadhosts` sourcetype=splunk_resource_usage component=PerProcess data.search_props.sid=*\
 | stats max(data.mem_used) AS peak_mem_usage,\
     latest(data.search_props.mode) AS mode,\
@@ -4300,7 +4300,7 @@ display.visualizations.show = 0
 description = Report only? Yes. As found on SplunkAnswers check the maximum memory usage per-search ( https://answers.splunk.com/answers/500973/how-to-improve-my-search-to-identify-queries-which.html )
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("As originally found on https://answers.splunk.com/answers/500973/how-to-improve-my-search-to-identify-queries-which.html / DalJeanis with minor modifications. Max memory used per search process at search head level")`\
+search = ```As originally found on https://answers.splunk.com/answers/500973/how-to-improve-my-search-to-identify-queries-which.html / DalJeanis with minor modifications. Max memory used per search process at search head level```\
 index=_introspection `indexerhosts` sourcetype=splunk_resource_usage component=PerProcess data.search_props.sid=*\
 | stats max(data.mem_used) AS peak_mem_usage,\
     latest(data.search_props.mode) AS mode,\
@@ -4335,7 +4335,7 @@ display.visualizations.show = 0
 description = Report only? Yes. Based on the Detect Excessive Search Use dashboard, attempt to automate detection of dashboards loaded by multiple users 
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Based on contents of Detect Excessive Search Use, with the addition of narrowing down to dashboard loads with more than 1 user. From there, attempt to auto-run the introspection index query to determine which dashboards may be involved and which apps. Finally this finishes with a sendresults email to the customer to advise them to consider changing their dashboard to use scheduled saved searches")`\
+search = ```Based on contents of Detect Excessive Search Use, with the addition of narrowing down to dashboard loads with more than 1 user. From there, attempt to auto-run the introspection index query to determine which dashboards may be involved and which apps. Finally this finishes with a sendresults email to the customer to advise them to consider changing their dashboard to use scheduled saved searches```\
 index=_audit info=granted "search='" NOT "savedsearch_name=\"Threat - Correlation Searches - Lookup Gen\"" NOT "savedsearch_name=\"Bucket Copy Trigger\"" NOT "search='| copybuckets" NOT "search='search index=_telemetry sourcetype=splunk_telemetry | spath" NOT "savedsearch_name=\"_ACCELERATE_*"\
 | rex "(?s), search='(?P<search>.*)\]$" \
 | regex search!="\|\s+(rest|inputlookup|makeresults|tstats count AS \"Count of [^\"]+\"\s+ from sid=)"\
@@ -4369,7 +4369,7 @@ index=_audit info=granted "search='" NOT "savedsearch_name=\"Threat - Correlatio
     | stats count, values(users) AS userList, values(loadCount) AS loadCount, values(searchDuration) AS searchDuration by data.search_props.provenance, data.search_props.app\
     | search data.search_props.provenance=UI:Dashboard*\
     | rename data.search_props.provenance AS provenance, data.search_props.app AS app ] maxsearches=20\
-| search `comment("Exclusions lists apply at this point as we have app/dashboard context")` NOT [ | inputlookup dashboard_automated_app_exclusion.csv ]  NOT [ | inputlookup dashboard_automated_app_history.csv | makemv searchInfo tokenizer=(\S+) | mvexpand searchInfo | rename searchInfo AS provenance | fields - currtime ]\
+| search ```Exclusions lists apply at this point as we have app/dashboard context``` NOT [ | inputlookup dashboard_automated_app_exclusion.csv ]  NOT [ | inputlookup dashboard_automated_app_history.csv | makemv searchInfo tokenizer=(\S+) | mvexpand searchInfo | rename searchInfo AS provenance | fields - currtime ]\
 | makemv userList\
 | eval userCount = mvcount(userList)\
 | mvexpand userList\
@@ -4405,7 +4405,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Find if the HEC is throwing errors. Refer to https://docs.splunk.com/Documentation/Splunk/latest/Data/TroubleshootHTTPEventCollector for more information")` \
+search = ```Find if the HEC is throwing errors. Refer to https://docs.splunk.com/Documentation/Splunk/latest/Data/TroubleshootHTTPEventCollector for more information``` \
 index=_internal "ERROR HttpInputDataHandler" sourcetype=splunkd (`splunkadmins_splunkd_source`) `splunkenterprisehosts` \
 | eval event_message=coalesce(event_message,message) \
 | rex field=event_message mode=sed "s/(http_input_body_size=)\d+|(totalRequestSize=)\d+/\1/" \
@@ -4432,8 +4432,8 @@ display.visualizations.show = 0
 description = Report only? Yes. Excessive CSV lookup updates can trigger extra bundle replication issues to the indexer cluster(s), this report identifies the lookups with the largest number of updates 
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Excessive CSV lookup updates can trigger extra bundle replication issues to the indexer cluster(s), this report identifies the lookups with the largest number of updates")`\
-index=_internal `searchheadhosts` source=*conf.log sourcetype=splunkd_conf lookups "data.asset_uri{}"=lookups "data.optype_desc"=NOTIFY_UPDATE_LOOKUP `comment("data.task=acceptPush also appears to work...")` data.task=addCommit \
+search = ```Excessive CSV lookup updates can trigger extra bundle replication issues to the indexer cluster(s), this report identifies the lookups with the largest number of updates```\
+index=_internal `searchheadhosts` source=*conf.log sourcetype=splunkd_conf lookups "data.asset_uri{}"=lookups "data.optype_desc"=NOTIFY_UPDATE_LOOKUP ```data.task=acceptPush also appears to work...``` data.task=addCommit \
 | rename "data.asset_uri{}" AS asset\
 | eval lookup_user=mvindex(asset, 0), lookup_app=mvindex(asset, 1), lookup_file=mvindex(asset, 3)\
 | stats min(_time) AS firstSeen, max(_time) AS lastSeen, count by lookup_file\
@@ -4453,8 +4453,8 @@ display.visualizations.show = 0
 description = Report only? Yes. Attempt to query the indexing tier to determine how often they are receiving new knowledge bundles from the various search tiers. From here calculate the time period between uploads, how long it takes and how many bundles during the time period
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Query the indexing tier to determine how often they are receiving new knowledge bundles from the various search tiers. From here calculate the time period between uploads, how long it takes and how many bundles during the time period")`\
-    `comment("Alternatives would be to check the bundle uploads via: 'index=_internal sourcetype=splunkd source=*metrics.log* group=bundles_uploads' or the bundle downloads with group=bundles_downloads, in particular the baseline_count/delta_count appear to show the different methods used but it appears to be more accurate to check the splunkd access logs on the indexing tier itself in 7.0.x. In 8.0.x the cascading bundle adds various complications, if no cascading bundle is in use you can drop the appends completely")`\
+search = ```Query the indexing tier to determine how often they are receiving new knowledge bundles from the various search tiers. From here calculate the time period between uploads, how long it takes and how many bundles during the time period```\
+    ```Alternatives would be to check the bundle uploads via: 'index=_internal sourcetype=splunkd source=*metrics.log* group=bundles_uploads' or the bundle downloads with group=bundles_downloads, in particular the baseline_count/delta_count appear to show the different methods used but it appears to be more accurate to check the splunkd access logs on the indexing tier itself in 7.0.x. In 8.0.x the cascading bundle adds various complications, if no cascading bundle is in use you can drop the appends completely```\
     index=_internal `indexerhosts` sourcetype=splunkd_access source=*splunkd_access.log (/services/receivers/bundle OR /services/replication/cascading/upload/payload) method=POST \
 | rex field=uri "/services/receivers/(?P<type>[^/]+)/(?P<guid>[^/]+)" \
 | rex field=uri "/cascading/upload/payload/(?P<planid>[^/]+)$" \
@@ -4482,7 +4482,7 @@ search = `comment("Query the indexing tier to determine how often they are recei
     | eval deploy_time=mostrecenttime-earliesttime \
     | rename bundle_type AS type \
     | fields guid, type, deploy_time, max_apply_time_msec, avg_apply_time_msec, replication_mode ] \
-| search `comment("The metrics.log uses delta_bundle, the other logs use bundle-delta or a variation of it")` \
+| search ```The metrics.log uses delta_bundle, the other logs use bundle-delta or a variation of it``` \
 | eval type=case(type=="delta_bundle","delta-bundle",type=="full_bundle","full-bundle",type=="bundle-delta","delta-bundle",type=="bundle","full-bundle",1=1,type) \
 | eval guid=if(match(guid,"\."),guid,upper(guid)) \
 | stats latest(_time) AS mostRecent, max(bundleUploadCount) AS bundleUploadsInTimePeriod, max(delta) AS largestTimeDeltaInSeconds, min(delta) AS minTimeDeltaInSeconds, avg(avg_apply_time_msec) AS avgApplySeconds, max(max_apply_time_msec) AS maxApplySeconds, min(deploy_time) AS min_deploy_time, max(deploy_time) AS max_deploy_time, avg(deploy_time) AS avg_deploy_time, values(replication_mode) AS replication_mode by guid, type \
@@ -4504,7 +4504,7 @@ display.page.search.patterns.sensitivity = 0.866
 display.page.search.tab = statistics
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = search `comment("remove the comments once you have Webtools Add-on, https://splunkbase.splunk.com/app/4146 installed to use the curl command...<begin> | curl ")` method=get uri="$url$/services/authorization/roles?output_mode=json&count=0&f=srchIndexesAllowed&f=srchIndexesDefault&f=imported_srchIndexesAllowed&f=imported_srchIndexesDefault" user="$user$" pass="$pass$" \
+search = search ```remove the comments once you have Webtools Add-on, https://splunkbase.splunk.com/app/4146 installed to use the curl command...<begin> | curl ``` method=get uri="$url$/services/authorization/roles?output_mode=json&count=0&f=srchIndexesAllowed&f=srchIndexesDefault&f=imported_srchIndexesAllowed&f=imported_srchIndexesDefault" user="$user$" pass="$pass$" \
 | rex field=curl_message max_match=10000 "{\"name\":\"(?P<role>[^\"]+)\".*?\"imported_srchIndexesAllowed\":(?P<imported_srchIndexesAllowed>\[[^\]]*\]),\"imported_srchIndexesDefault\":(?P<imported_srchIndexesDefault>\[[^\]]*\]),\"srchIndexesAllowed\":(?P<srchIndexesAllowed>\[[^\]]*\]),\"srchIndexesDefault\":(?P<srchIndexesDefault>\[[^\]]*\])" \
 | fields - curl_* \
 | eval srchIndexesAllowed=mvzip(srchIndexesAllowed,imported_srchIndexesAllowed) \
@@ -4612,7 +4612,7 @@ search = | rest /services/authorization/roles splunk_server="local" \
 | stats values(srchIndexesAllowed) AS srchIndexesAllowed, values(index) AS srchIndexesDefault by roles, splunk_server \
 | makemv srchIndexesAllowed tokenizer=(\S+) \
 | eval srchIndexesDefault = if(srchIndexesDefault=="requiredformvexpand",null(),srchIndexesDefault)\
-| search `comment("You can add this in if you have mutiple search head clusters or search heads after removing the backspaces...| append [ savedsearch \"SearchHeadLevel - IndexesPerRole Remote Report\" url=\"...\" user=\"...\" pass=\"...\" | eval splunk_server="..." ]")`\
+| search ```You can add this in if you have mutiple search head clusters or search heads after removing the backspaces...| append [ savedsearch \"SearchHeadLevel - IndexesPerRole Remote Report\" url=\"...\" user=\"...\" pass=\"...\" | eval splunk_server="..." ]```\
 | outputlookup splunkadmins_indexes_per_role
 
 [SearchHeadLevel - Search Queries summary exact match]
@@ -4626,11 +4626,11 @@ display.general.type = statistics
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | multisearch \
-    [ search `comment("Last modified 2022-02-14 Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. The multisearch is only required if you want to capture sub-searches from join, append or similar, these require a bit more work so that's why the multisearch is there, in fact anything containing one of those keywords is dealt with in the second search, not this one...")` \
-    `comment("Note that the regexes need more work, for now, limits.conf [rex] match_limit = 1000000 is my workaround (main issue is the union/set/multisearch rex)")` \
+    [ search ```Last modified 2022-02-14 Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. The multisearch is only required if you want to capture sub-searches from join, append or similar, these require a bit more work so that's why the multisearch is there, in fact anything containing one of those keywords is dealt with in the second search, not this one...``` \
+    ```Note that the regexes need more work, for now, limits.conf [rex] match_limit = 1000000 is my workaround (main issue is the union/set/multisearch rex)``` \
         index=_audit "info=completed" search_id!="'SummaryDirector_*" search_id!="'rsa_*" search_id!="'RemoteStorageRetrieveBuckets_*" search_id!="'ta_*" search_id!="'RemoteStorageRetrieveIndexes*" scan_count>0 \
     | rex "(?s), search='(?P<search>.*)\]$" \
-    | search `comment("Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"")` \
+    | search ```Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"``` \
     | rex field=search mode=sed "s/\n/ /g" \
     | rex field=search mode=sed "s/```.*?```/ /g" \
     | eval search=if(substr(search,len(search),len(search)-1)=="'",substr(search,0,len(search)-1),search) \
@@ -4641,7 +4641,7 @@ search = | multisearch \
     | eval app_name=coalesce(app,base64appname,app3) \
     | fillnull app_name value="*" \
     | eval splunk_server = `splunkadmins_splunk_server_name` \
-    | search `comment("Replace macros, but then replace datamodels, then tags, then eventtypes, but what if the eventtype refers to an eventtype? Or tag? Or more macros? This isn't perfect so just substitute a hope for the best. IndexerLevel - RemoteSearches Indexes Stats doesn't have all these issues so it may be safer to see what happens at indexing tier...Note pre Splunk 8.0 you will need to replace splunkadmins_audit_logs_macro_sub_v8 with splunkadmins_audit_logs_macro_sub")` \
+    | search ```Replace macros, but then replace datamodels, then tags, then eventtypes, but what if the eventtype refers to an eventtype? Or tag? Or more macros? This isn't perfect so just substitute a hope for the best. IndexerLevel - RemoteSearches Indexes Stats doesn't have all these issues so it may be safer to see what happens at indexing tier...Note pre Splunk 8.0 you will need to replace splunkadmins_audit_logs_macro_sub_v8 with splunkadmins_audit_logs_macro_sub``` \
     | `splunkadmins_macro_sub("search")` \
     | `splunkadmins_macro_sub("search")` \
     | regex search="^\s*(\|?)\s*(search|tstats|mstats|mcatalog|mutlisearch|union|set|summarize|datamodel|from\s*:?\s*datamodel|datamodelsimple)\s+" \
@@ -4656,10 +4656,10 @@ search = | multisearch \
     | rex field=search mode=sed "s/\n/ /g"\
     | rex field=search mode=sed "s/```.*?```/ /g" \
     | rex field=search "(?s)^(?P<prepipe>\s*\|?([^\|]+))" ] \
-    [ search `comment("Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. This search works on searches with an append/multisearch or other command that has a slightly different regex requirement. Note had to nomv the multivalued field before concatenation or it sliently disappeared!")` \
+    [ search ```Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. This search works on searches with an append/multisearch or other command that has a slightly different regex requirement. Note had to nomv the multivalued field before concatenation or it sliently disappeared!``` \
         index=_audit "info=completed" search_id!="'SummaryDirector_*" search_id!="'rsa_*" search_id!="'RemoteStorageRetrieveBuckets_*" search_id!="'ta_*" search_id!="'RemoteStorageRetrieveIndexes*" scan_count>0 \
     | rex "(?s), search='(?P<search>.*)\]$" \
-    | search `comment("Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"")` \
+    | search ```Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"``` \
     | rex field=search mode=sed "s/\n/ /g"\
     | rex field=search mode=sed "s/```.*?```/ /g" \
     | eval search=if(substr(search,len(search),len(search)-1)=="'",substr(search,0,len(search)-1),search) \
@@ -4670,7 +4670,7 @@ search = | multisearch \
     | eval app_name=coalesce(app,base64appname,app3) \
     | fillnull app_name value="*" \
     | eval splunk_server = `splunkadmins_splunk_server_name` \
-    | search `comment("Replace macros, but then replace datamodels, then tags, then eventtypes, but what if the eventtype refers to an eventtype? Or tag? Or more macros? This isn't perfect so just substitute a hope for the best. IndexerLevel - RemoteSearches Indexes Stats doesn't have all these issues so it may be safer to see what happens at indexing tier...")` \
+    | search ```Replace macros, but then replace datamodels, then tags, then eventtypes, but what if the eventtype refers to an eventtype? Or tag? Or more macros? This isn't perfect so just substitute a hope for the best. IndexerLevel - RemoteSearches Indexes Stats doesn't have all these issues so it may be safer to see what happens at indexing tier...``` \
     | `splunkadmins_macro_sub("search")` \
     | `splunkadmins_macro_sub("search")` \
     | regex search="\|\s*(append|union|multisearch|set|appendcols|appendpipe|join|map)" \
@@ -4694,16 +4694,16 @@ search = | multisearch \
     | eval prepipe = prepipe . " " . prepipe_subsearch \
         ] \
 | eval search=prepipe \
-| search `comment("The (index=* OR index=_*) index=<specific index> is a common use case for enterprise security, also some individuals like doing a similar trick so remove the index=*... as this is not a wildcard index search")` \
+| search ```The (index=* OR index=_*) index=<specific index> is a common use case for enterprise security, also some individuals like doing a similar trick so remove the index=*... as this is not a wildcard index search``` \
 | rex field=search "(?P<esstylewildcard>\(\s*index=\*\s+OR\s+index=_\*\s*\))" \
 | rex mode=sed field=search "s/search index=\s*\S+\s+index\s*=/search index=/g" \
 | eval search_head=host \
 | eval search_head_cluster=`search_head_cluster` \
 | rex ", savedsearch_name=\"(?P<savedsearch_name>[^\"]+)\","\
 | stats values(total_run_time) AS total_run_time, values(event_count) AS event_count, values(scan_count) AS scan_count, values(search) AS search, values(search_et) AS search_et, values(search_lt) AS search_lt, values(savedsearch_name) AS savedsearch_name, min(_time) AS timestamp, values(search_head_cluster) AS search_head_cluster, max(duration_command_search_index) AS duration_index, max(duration_command_search_rawdata) AS duration_rawdata, max(invocations_command_search_index_bucketcache_hit) AS cache_index_hits, max(invocations_command_search_index_bucketcache_miss) AS cache_index_miss, max(duration_command_search_index_bucketcache_hit) AS cache_index_hit_duration, max(duration_command_search_index_bucketcache_miss) AS cache_index_miss_duration, max(invocations_command_search_rawdata_bucketcache_hit) AS cache_rawdata_hits, max(invocations_command_search_rawdata_bucketcache_miss) AS cache_rawdata_miss, max(duration_command_search_rawdata_bucketcache_hit) AS cache_rawdata_hit_duration, max(duration_command_search_rawdata_bucketcache_miss) AS cache_rawdata_miss_duration, values(esstylewildcard) AS esstylewildcard, values(provenance) AS provenance by user, type, search_id, app_name \
-| search `comment("We now deal with cases where search earliest/latest times were not specified, assume all time is about 1 year in the past and latest time was the search run time")` \
+| search ```We now deal with cases where search earliest/latest times were not specified, assume all time is about 1 year in the past and latest time was the search run time``` \
 | eval search_lt=if(search_lt=="N/A",timestamp,search_lt), search_et=if(search_et=="N/A",now()-(365*24*60*60),search_et) \
-| search `comment("Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements")` \
+| search ```Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements``` \
 | rex field=search "(?s)(NOT\s+index(\s*=\s*|::)[^ ]+)|(NOT\s+\([^\)]+\))|(index(\s*=\s*|::)\"?(?P<indexregex>[\*A-Za-z0-9-_]+))" max_match=50 \
 | rex field=search "(?s)(NOT\s+index\s+[iI][nN]\s*\([^\)]+)|(index\s+[iI][nN]\s*\((?P<indexin>([^\)\"]+)|\"[^\)\"]+\"))" max_match=50 \
 | makemv delim="," indexin \
@@ -4718,7 +4718,7 @@ search = | multisearch \
 | stats values(timestamp) AS _time, values(total_run_time) AS total_run_time, values(event_count) AS event_count, values(scan_count) AS scan_count, values(search_et) AS search_et, values(search_lt) AS search_lt, values(savedsearch_name) AS savedsearch_name, values(multi) AS multi, max(duration_index) AS duration_index, max(duration_rawdata) AS duration_rawdata, max(cache_index_hits) AS cache_index_hits, max(cache_index_miss) AS cache_index_miss, max(cache_index_hit_duration) AS cache_index_hit_duration, max(cache_index_miss_duration) AS cache_index_miss_duration, max(cache_rawdata_hits) AS cache_rawdata_hits, max(cache_rawdata_miss) AS cache_rawdata_miss, max(cache_rawdata_hit_duration) AS cache_rawdata_hit_duration, max(cache_rawdata_miss_duration) AS cache_rawdata_miss_duration, values(provenance) AS provenance by user, type, indexes, search_head_cluster, search_id, app_name \
 | eval period=search_lt-search_et \
 | fields - indexin, indexregex \
-| search `comment("Commands like multikv result in giant event count numbers compared to scan count, lower the lispy back down to normal to prevent the stats from been broken. lispy efficiency as per Martin Muller's conf presentations")` \
+| search ```Commands like multikv result in giant event count numbers compared to scan count, lower the lispy back down to normal to prevent the stats from been broken. lispy efficiency as per Martin Muller's conf presentations``` \
 | eval lispy_efficiency = if(event_count>scan_count,scan_count,event_count) / scan_count
 
 [SearchHeadLevel - Search Queries summary non-exact match]
@@ -4733,11 +4733,11 @@ display.page.search.tab = statistics
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | multisearch \
-    [ search `comment("Last modified 2022-02-14 Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. The multisearch is only required if you want to capture sub-searches from join, append or similar, these require a bit more work so that's why the multisearch is there, in fact anything containing one of those keywords is dealt with in the second search, not this one...")` \
-    `comment("Note that the regexes need more work, for now, limits.conf [rex] match_limit = 1000000 is my workaround (main issue is the union/set/multisearch rex)")` \
+    [ search ```Last modified 2022-02-14 Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. The multisearch is only required if you want to capture sub-searches from join, append or similar, these require a bit more work so that's why the multisearch is there, in fact anything containing one of those keywords is dealt with in the second search, not this one...``` \
+    ```Note that the regexes need more work, for now, limits.conf [rex] match_limit = 1000000 is my workaround (main issue is the union/set/multisearch rex)``` \
         index=_audit "info=completed" search_id!="'SummaryDirector_*" search_id!="'rsa_*" search_id!="'RemoteStorageRetrieveBuckets_*" search_id!="'ta_*" search_id!="'RemoteStorageRetrieveIndexes*" scan_count>0 \
     | rex "(?s), search='(?P<search>.*)\]$" \
-    | search `comment("Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"")` \
+    | search ```Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"``` \
     | rex field=search mode=sed "s/\n/ /g"\
     | rex field=search mode=sed "s/```.*?```/ /g" \
     | eval search=if(substr(search,len(search),len(search)-1)=="'",substr(search,0,len(search)-1),search) \
@@ -4748,7 +4748,7 @@ search = | multisearch \
     | eval app_name=coalesce(app,base64appname,app3) \
     | fillnull app_name value="*" \
     | eval splunk_server = `splunkadmins_splunk_server_name` \
-    | search `comment("Replace macros, but then replace datamodels, then tags, then eventtypes, but what if the eventtype refers to an eventtype? Or tag? Or more macros? This isn't perfect so just substitute a hope for the best. IndexerLevel - RemoteSearches Indexes Stats doesn't have all these issues so it may be safer to see what happens at indexing tier...")` \
+    | search ```Replace macros, but then replace datamodels, then tags, then eventtypes, but what if the eventtype refers to an eventtype? Or tag? Or more macros? This isn't perfect so just substitute a hope for the best. IndexerLevel - RemoteSearches Indexes Stats doesn't have all these issues so it may be safer to see what happens at indexing tier...``` \
     | `splunkadmins_macro_sub("search")` \
     | `splunkadmins_macro_sub("search")` \
     | regex search="^\s*(\|?)\s*(search|tstats|mstats|mcatalog|mutlisearch|union|set|summarize|datamodel|from\s*:?\s*datamodel|datamodelsimple)\s+" \
@@ -4763,10 +4763,10 @@ search = | multisearch \
     | rex field=search mode=sed "s/\n/ /g"\
     | rex field=search mode=sed "s/```.*?```/ /g" \
     | rex field=search "(?s)^(?P<prepipe>\s*\|?([^\|]+))" ] \
-    [ search `comment("Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. This search works on searches with an append/multisearch or other command that has a slightly different regex requirement. Note had to nomv the multivalued field before concatenation or it sliently disappeared!")` \
+    [ search ```Attempt to extract out which indexes are accessed per search query by any search and compute statistics on them. This search works on searches with an append/multisearch or other command that has a slightly different regex requirement. Note had to nomv the multivalued field before concatenation or it sliently disappeared!``` \
         index=_audit "info=completed" search_id!="'SummaryDirector_*" search_id!="'rsa_*" search_id!="'RemoteStorageRetrieveBuckets_*" search_id!="'ta_*" search_id!="'RemoteStorageRetrieveIndexes*" scan_count>0 \
     | rex "(?s), search='(?P<search>.*)\]$" \
-    | search `comment("Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"")` \
+    | search ```Removed due to excess matching, modern splunk versions appear to match search= more accurately | rex \"(?s)^(?:[^'\n]*'){4},\s+\w+='(?P<search>[\s\S]+)'\]($|\[[^\]]+\]$)\"``` \
     | rex field=search mode=sed "s/\n/ /g"\
     | rex field=search mode=sed "s/```.*?```/ /g" \
     | eval search=if(substr(search,len(search),len(search)-1)=="'",substr(search,0,len(search)-1),search) \
@@ -4777,7 +4777,7 @@ search = | multisearch \
     | eval app_name=coalesce(app,base64appname,app3) \
     | eval splunk_server = `splunkadmins_splunk_server_name` \
     | fillnull app_name value="*" \
-    | search `comment("Replace macros, but then replace datamodels, then tags, then eventtypes, but what if the eventtype refers to an eventtype? Or tag? Or more macros? This isn't perfect so just substitute a hope for the best. IndexerLevel - RemoteSearches Indexes Stats doesn't have all these issues so it may be safer to see what happens at indexing tier...")` \
+    | search ```Replace macros, but then replace datamodels, then tags, then eventtypes, but what if the eventtype refers to an eventtype? Or tag? Or more macros? This isn't perfect so just substitute a hope for the best. IndexerLevel - RemoteSearches Indexes Stats doesn't have all these issues so it may be safer to see what happens at indexing tier...``` \
     | `splunkadmins_macro_sub("search")` \
     | `splunkadmins_macro_sub("search")` \
     | regex search="\|\s*(append|union|multisearch|set|appendcols|appendpipe|join|map)" \
@@ -4800,10 +4800,10 @@ search = | multisearch \
     | nomv prepipe_subsearch \
     | eval prepipe = prepipe . " " . prepipe_subsearch ] \
 | eval search=prepipe \
-| search `comment("The (index=* OR index=_*) index=<specific index> is a common use case for enterprise security, also some individuals like doing a similar trick so remove the index=*... as this is not a wildcard index search")` \
+| search ```The (index=* OR index=_*) index=<specific index> is a common use case for enterprise security, also some individuals like doing a similar trick so remove the index=*... as this is not a wildcard index search``` \
 | rex field=search "(?P<esstylewildcard>\(\s*index=\*\s+OR\s+index=_\*\s*\))" \
 | rex mode=sed field=search "s/search index=\s*\S+\s+index\s*=/search index=/g" \
-| search `comment("Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements")` \
+| search ```Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements``` \
 | rex field=search "(?s)(NOT\s+index(\s*=\s*|::)[^ ]+)|(NOT\s+\([^\)]+\))|(index(\s*=\s*|::)\"?(?P<indexregex>[\*A-Za-z0-9-_]+))" max_match=50 \
 | rex field=search "(?s)(NOT\s+index\s+[iI][nN]\s*\([^\)]+)|(index\s+[iI][nN]\s*\((?P<indexin>([^\)\"]+)|\"[^\)\"]+\"))" max_match=50 \
 | makemv delim="," indexin \
@@ -4813,11 +4813,11 @@ search = | multisearch \
 | where isnotnull(wildcard) OR isnull(indexes) \
 | eval short=mvmap(indexes,if(len(indexes)<=3,"True",null())) \
 | eval short=if(isnull(short),"False","True") \
-| search `comment("We now deal with cases where search earliest/latest times were not specified, assume all time is about 1 year in the past and latest time was the search run time")` \
+| search ```We now deal with cases where search earliest/latest times were not specified, assume all time is about 1 year in the past and latest time was the search run time``` \
 | eval search_lt=if(search_lt=="N/A",_time,search_lt), search_et=if(search_et=="N/A",now()-(365*24*60*60),search_et) \
 | eval period=search_lt-search_et \
-| search `comment("Now that we have a giant list of indexes, we want to strip any quote characters and lowercase them in case we use a kvstore for lookups or similar.")` \
-| search `comment("Run a lookup to find the default indexes and the allowed indexes per user")` \
+| search ```Now that we have a giant list of indexes, we want to strip any quote characters and lowercase them in case we use a kvstore for lookups or similar.``` \
+| search ```Run a lookup to find the default indexes and the allowed indexes per user``` \
 | eval roles=replace(roles,"'","") \
 | makemv roles delim="+" \
 | lookup splunkadmins_indexes_per_role roles, splunk_server \
@@ -4835,7 +4835,7 @@ search = | multisearch \
 | eval multi=if(mvcount(indexes)>1,"true","false") \
 | stats values(_time) AS _time, values(total_run_time) AS total_run_time, values(event_count) AS event_count, values(scan_count) AS scan_count, values(search_et) AS search_et, values(search_lt) AS search_lt, values(savedsearch_name) AS savedsearch_name, values(multi) AS multi, max(duration_command_search_index) AS duration_index, max(duration_command_search_rawdata) AS duration_rawdata, max(invocations_command_search_index_bucketcache_hit) AS cache_index_hits, max(invocations_command_search_index_bucketcache_miss) AS cache_index_miss, max(duration_command_search_index_bucketcache_hit) AS cache_index_hit_duration, max(duration_command_search_index_bucketcache_miss) AS cache_index_miss_duration, max(invocations_command_search_rawdata_bucketcache_hit) AS cache_rawdata_hits, max(invocations_command_search_rawdata_bucketcache_miss) AS cache_rawdata_miss, max(duration_command_search_rawdata_bucketcache_hit) AS cache_rawdata_hit_duration, max(duration_command_search_rawdata_bucketcache_miss) AS cache_rawdata_miss_duration, values(provenance) AS provenance by user, type, search_id, indexes, search_head_cluster, app_name, short \
 | eval period=search_lt-search_et \
-| search `comment("Commands like multikv result in giant event count numbers compared to scan count, lower the lispy back down to normal to prevent the stats from been broken. lispy efficiency as per Martin Muller's conf presentations")` \
+| search ```Commands like multikv result in giant event count numbers compared to scan count, lower the lispy back down to normal to prevent the stats from been broken. lispy efficiency as per Martin Muller's conf presentations``` \
 | eval lispy_efficiency = if(event_count>scan_count,scan_count,event_count) / scan_count
 
 [SearchHeadLevel - Search Queries summary exact match by user]
@@ -4849,7 +4849,7 @@ display.general.type = statistics
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | savedsearch "SearchHeadLevel - Search Queries summary exact match"\
-| search `comment("TODO breakdown the counts into time periods, perhaps 1hour, 4 hours, 8 hours, 24 hours, 3 days, 7 days, 14 days, 21 days, 30 days, 2 months, 3 months, 6months, > 60 months? or similar. Do a count for each one as that would be useful for a dashboard...")` \
+| search ```TODO breakdown the counts into time periods, perhaps 1hour, 4 hours, 8 hours, 24 hours, 3 days, 7 days, 14 days, 21 days, 30 days, 2 months, 3 months, 6months, > 60 months? or similar. Do a count for each one as that would be useful for a dashboard...``` \
 | stats count, dc(indexes) AS indexes, max(period) AS maxPeriod, avg(period) AS avgPeriod, median(period) AS medianPeriod, \
     avg(total_run_time) AS avg_total_run_time, max(total_run_time) AS max_total_run_time, median(total_run_time) AS median_total_run_time, avg(lispy_efficiency) AS avg_lispy_efficiency, max(lispy_efficiency) AS max_lispy_efficiency, min(lispy_efficiency) AS min_lispy_efficiency, median(lispy_efficiency) AS median_lispy_efficiency by user\
 | fillnull max_lispy_efficiency, min_lispy_efficiency, median_lispy_efficiency \
@@ -4869,7 +4869,7 @@ search = | savedsearch "SearchHeadLevel - Search Queries summary exact match"\
 | eval period=case(period<900,"a<=15 minutes",period<3600,"b<=1hour",period<=14400,"c<=4hours",period<=86400,"d<=24hours",period<=604800,"e<=7days",period<=1209600,"f<=14days",period<=2592000,"g<=30days",period<=5184000,"h<=60days",period<=7776000,"i<=90days",period<=15552000,"j<=180days",period>15552000,"k>180days")\
 | stats count by indexes, period\
 | rename indexes AS index\
-| search `comment("Temporary hack to make this visualize without errors below...")`\
+| search ```Temporary hack to make this visualize without errors below...```\
 | eval indexfirstletter=substr(index,0,1)\
 | stats sum(count) AS count by indexfirstletter, period\
 | xyseries period indexfirstletter count
@@ -4941,8 +4941,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to detect bundle issues on any member of the search head cluster for an extended period of time. It can fail per-member if distsearch is customised")` index=_internal `searchheadhosts` sourcetype=splunkd `splunkadmins_splunkd_source` "Gave up waiting for the captain to establish a common bundle version" OR "Cannot determine a latest common bundle" OR (log_level=WARN AND component=DistributedBundleReplicationManager `comment("This is confirmed as an invalid warning message in Splunk 9")` NOT "Failed to touch bundle=, checksum=0 (manual preparation): No such file or directory") \
-| search `comment("Exclude shutdown times")` AND NOT [`splunkadmins_shutdown_time(indexerhosts,0,0)`]\
+search = ```Attempt to detect bundle issues on any member of the search head cluster for an extended period of time. It can fail per-member if distsearch is customised``` index=_internal `searchheadhosts` sourcetype=splunkd `splunkadmins_splunkd_source` "Gave up waiting for the captain to establish a common bundle version" OR "Cannot determine a latest common bundle" OR (log_level=WARN AND component=DistributedBundleReplicationManager ```This is confirmed as an invalid warning message in Splunk 9``` NOT "Failed to touch bundle=, checksum=0 (manual preparation): No such file or directory") \
+| search ```Exclude shutdown times``` AND NOT [`splunkadmins_shutdown_time(indexerhosts,0,0)`]\
 | timechart span=5m count by host\
 | fillnull\
 | untable _time, host, count\
@@ -4961,7 +4961,7 @@ display.events.fields = ["index","sourcetype","host","source"]
 display.general.type = statistics
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Measure search head clustering writes to particular config objects via the conf.log file")` index=_internal source=*conf.log data.task=addCommit sourcetype=splunkd_conf `searchheadhosts`\
+search = ```Measure search head clustering writes to particular config objects via the conf.log file``` index=_internal source=*conf.log data.task=addCommit sourcetype=splunkd_conf `searchheadhosts`\
 | spath output=username path=data.asset_uri{0}\
 | spath output=app path=data.asset_uri{1}\
 | spath output=type path=data.asset_uri{2}\
@@ -4991,7 +4991,7 @@ search = | tstats dc(host) AS unique_hosts where index=* earliest=-24h, latest=+
 | addinfo \
 | rename info_max_time AS _time \
 | fields - info_* \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix indexer_cluster")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix indexer_cluster```
 
 [IndexerLevel - platform_stats.counters hosts 24hour]
 action.email.useNSSubject = 1
@@ -5012,7 +5012,7 @@ search = | tstats dc(host) AS unique_hosts_24hr where index=*, earliest=-48h, la
 | addinfo \
 | rename info_max_time AS _time \
 | fields - info_* \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix indexer_cluster")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix indexer_cluster```
 
 [IndexerLevel - platform_stats.indexers totalgb measurement]
 action.email.useNSSubject = 1
@@ -5028,7 +5028,7 @@ enableSched = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = index=_internal `licensemasterhost` type=usage sourcetype=splunkd source=*license_usage.log*\
-`comment("Alternative query IndexerLevel - platform_stats.indexers totalgb_thruput measurement if you want the _internal indexes among others. This query uses license usage instead as we are measuring what non-internal data we are indexing")`\
+```Alternative query IndexerLevel - platform_stats.indexers totalgb_thruput measurement if you want the _internal indexes among others. This query uses license usage instead as we are measuring what non-internal data we are indexing```\
 | stats sum(b) AS totalbytes by i \
 | append \
     [| rest /services/search/distributed/peers \
@@ -5042,7 +5042,7 @@ search = index=_internal `licensemasterhost` type=usage sourcetype=splunkd sourc
 | addinfo \
 | rename info_max_time AS _time \
 | fields - info_* \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix indexer indexer_cluster")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix indexer indexer_cluster```
 
 [IndexerLevel - platform_stats.indexers totalgb_thruput measurement]
 action.email.useNSSubject = 1
@@ -5067,7 +5067,7 @@ search = index=_internal `indexerhosts` TERM(group=thruput) TERM(name=index_thru
 | rename info_max_time AS _time \
 | fields - info_*, totalkb \
 | rename host AS indexer \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix indexer indexer_cluster")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix indexer indexer_cluster```
 
 [IndexerLevel - platform_stats.indexers stddev measurement]
 action.email.useNSSubject = 1
@@ -5088,7 +5088,7 @@ search =  index=_internal `indexerhosts` sourcetype=splunkd `splunkadmins_metric
 | stats sum(instantaneous_kbps) as instantaneous_kbps by host _time indexer_cluster \
 | stats stdev(instantaneous_kbps) AS stdev_kbps by indexer_cluster, _time \
 | eval prefix="platform_stats.indexers." \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix indexer_cluster")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix indexer_cluster```
 
 [IndexerLevel - platform_stats.indexers stddev incoming measurement]
 action.email.useNSSubject = 1
@@ -5110,7 +5110,7 @@ search =  index=_internal `indexerhosts` sourcetype=splunkd `splunkadmins_metric
 | stats sum(kb) AS kb by host, indexer_cluster, name, _time \
 | eval kb=kb/60 \
 | stats stdev(kb) AS platform_stats.indexers.deviation_incoming by _time, indexer_cluster, name \
-`comment("| eval prefix=\"platform_stats.indexers." | mcollect index=a_metrics_index split=true prefix_field=prefix indexer_cluster, name")`
+```| eval prefix=\"platform_stats.indexers." | mcollect index=a_metrics_index split=true prefix_field=prefix indexer_cluster, name```
 
 [SearchHeadLevel - platform_stats.audit metrics searches]
 action.email.useNSSubject = 1
@@ -5125,16 +5125,16 @@ enableSched = 0
 realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Count the number of of Splunk queries that use a search command, excludes rest/data model acceleration et cetera")` \
+search = ```Count the number of of Splunk queries that use a search command, excludes rest/data model acceleration et cetera``` \
     index=_audit ", info=granted " search_id!="'rsa_*" \
 | rex "(?s), search='(?P<search>.*)\]$" \
 | regex search!="^(\| (copy|archive)buckets|typeahead|\s*archivebuckets)" \
-| search `comment("Unsure what this search does but it appears to be running when no reports are accelerated...")` \
+| search ```Unsure what this search does but it appears to be running when no reports are accelerated...``` \
 | regex search!="^summarize (tstats=t maintain=\"\" summaryprefix=\"[^\"]+\"|maintain=\"%22SUMMARY_ID%22%2C%22EARLIEST_TIME%22%2C%22REMOTE_SEARCH%22%2C%22NORM_SUMMARY_ID%22%2C%22NORM_REMOTE_SEARCH%22%0A\" summaryprefix=\"[^\"]+\")$" \
 | rex "info=granted , search_id='(?P<search_id>[^']+)" \
 | rex "', savedsearch_name=\"(?P<savedsearch_name>[^\"]*)" \
 | `search_type_from_sid(search_id)` \
-| search `comment("Split out the information by system vs non-system users. Adhoc/scheduled/dashboards split (as accurately as possible), furthermore you can trigger ad-hoc searches via scripted inputs which is similar to a scheduled search (but not via the scheduler)")` \
+| search ```Split out the information by system vs non-system users. Adhoc/scheduled/dashboards split (as accurately as possible), furthermore you can trigger ad-hoc searches via scripted inputs which is similar to a scheduled search (but not via the scheduler)``` \
 | eval user=if(user=="admin" OR user=="splunk-system-user","system","other") \
 | stats count AS search_count by host, type, user \
 | eval prefix="platform_stats.audit." \
@@ -5143,7 +5143,7 @@ search = `comment("Count the number of of Splunk queries that use a search comma
 | addinfo \
 | rename info_max_time AS _time \
 | fields - info_* \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix search_head search_head_cluster type user")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix search_head search_head_cluster type user```
 
 [SearchHeadLevel - platform_stats.audit metrics users]
 action.email.useNSSubject = 1
@@ -5159,13 +5159,13 @@ realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | multisearch \
-    [ search `comment("Count the number of of Splunk queries that use a search command")` \
+    [ search ```Count the number of of Splunk queries that use a search command``` \
     index=_audit ", info=granted " search_id!="'rsa_*" \
     | rex "(?s), search='(?P<search>.*)\]$" \
     ] \
-    [ search `comment("Attempt to find all API calls into Splunk but do not include the API calls triggered by the local system (ignore localhost")` \
+    [ search ```Attempt to find all API calls into Splunk but do not include the API calls triggered by the local system (ignore localhost``` \
         index=_internal sourcetype=splunkd_access source="*splunkd_access.log" "/search/jobs/export" OR ("/search/jobs" OR "/search/v1/jobs" OR "/search/v2/jobs" method=POST) NOT control clientip!=127.0.0.1 status=200 OR status=201 ] \
-| search `comment("Split out the information by users vs api users")` \
+| search ```Split out the information by users vs api users``` \
 | eval from=if(index=="_audit","ui","rest") \
 | stats dc(user) AS active_users by host, from \
 | eval prefix="platform_stats.audit." \
@@ -5174,7 +5174,7 @@ search = | multisearch \
 | addinfo \
 | rename info_max_time AS _time \
 | fields - info_* \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix search_head search_head_cluster from")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix search_head search_head_cluster from```
 
 [SearchHeadLevel - platform_stats.audit metrics api]
 action.email.useNSSubject = 1
@@ -5189,7 +5189,7 @@ enableSched = 0
 realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to find all API calls into Splunk but do not include the API calls triggered by the local system (ignore localhost")` \
+search = ```Attempt to find all API calls into Splunk but do not include the API calls triggered by the local system (ignore localhost``` \
     index=_internal sourcetype=splunkd_access source="*splunkd_access.log" "/search/jobs/export" OR ("/search/jobs" OR "/search/v1/jobs" OR "/search/v2/jobs" method=POST) NOT control clientip!=127.0.0.1 status=200 OR status=201 \
 | stats count AS api_search_count by host \
 | eval prefix="platform_stats.audit." \
@@ -5198,7 +5198,7 @@ search = `comment("Attempt to find all API calls into Splunk but do not include 
 | addinfo \
 | rename info_max_time AS _time \
 | fields - info_* \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix search_head search_head_cluster")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix search_head search_head_cluster```
 
 [SearchHeadLevel - platform_stats.audit metrics users 24hour]
 action.email.useNSSubject = 1
@@ -5214,13 +5214,13 @@ realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | multisearch \
-    [ search `comment("Count the number of of Splunk queries that use a search command")` \
+    [ search ```Count the number of of Splunk queries that use a search command``` \
     index=_audit ", info=granted " search_id!="'rsa_*" \
     | rex "(?s), search='(?P<search>.*)\]$" \
     ] \
-    [ search `comment("Attempt to find all API calls into Splunk but do not include the API calls triggered by the local system (ignore localhost")` \
+    [ search ```Attempt to find all API calls into Splunk but do not include the API calls triggered by the local system (ignore localhost``` \
         index=_internal sourcetype=splunkd_access source="*splunkd_access.log" "/search/jobs/export" OR ("/search/jobs" OR "/search/v1/jobs" OR "/search/v2/jobs" method=POST) NOT control clientip!=127.0.0.1 status=200 OR status=201 ] \
-| search `comment("Split out the information by users vs api users")` \
+| search ```Split out the information by users vs api users``` \
 | eval from=if(index=="_audit","ui","rest")\
 | eval search_head=host\
 | eval search_head_cluster=`search_head_cluster`\
@@ -5229,7 +5229,7 @@ search = | multisearch \
 | addinfo\
 | rename info_max_time AS _time\
 | fields - info_*\
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix search_head search_head_cluster from")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix search_head search_head_cluster from```
 
 [SearchHeadLevel - platform_stats.user_stats.introspection metrics populating search]
 action.email.useNSSubject = 1
@@ -5275,7 +5275,7 @@ search = index=_introspection `indexerhosts` sourcetype=splunk_resource_usage da
 | fields - info_* \
 | foreach user_stats.introspection.* [eval <<FIELD>>=round('<<FIELD>>',2)] \
 | fillnull \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, type, user, indexer_cluster, app")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, type, user, indexer_cluster, app```
 
 [SearchHeadLevel - platform_stats access summary]
 action.email.useNSSubject = 1
@@ -5342,8 +5342,8 @@ enableSched = 0
 realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to gather stats from the remote_searches log on the indexing tier relating to the searches from various search heads. These may include search heads where we do not see the _audit index. Added regex to ignore the strange presummarize that comes in from search heads that do not have accelerated reports...")` \
-index=_internal `indexerhosts` sourcetype=splunkd_remote_searches source="/opt/splunk/var/log/splunk/remote_searches.log" terminated: OR closed: `comment("Note that TERM(starting) has the apiStartTime, apiEndTime stats, but lacks the useful stats from a search that is complete. Also note that on indexers scan_count=events_count (in my testing). Finally various fields failed to auto-extract so regexes are used now, perhaps due to the length of some searches...")` \
+search = ```Attempt to gather stats from the remote_searches log on the indexing tier relating to the searches from various search heads. These may include search heads where we do not see the _audit index. Added regex to ignore the strange presummarize that comes in from search heads that do not have accelerated reports...``` \
+index=_internal `indexerhosts` sourcetype=splunkd_remote_searches source="/opt/splunk/var/log/splunk/remote_searches.log" terminated: OR closed: ```Note that TERM(starting) has the apiStartTime, apiEndTime stats, but lacks the useful stats from a search that is complete. Also note that on indexers scan_count=events_count (in my testing). Finally various fields failed to auto-extract so regexes are used now, perhaps due to the length of some searches...``` \
 | rex "(?s) elapsedTime=(?P<elapsedTime>[0-9\.]+), search='(?P<search>.*?)(', savedsearch_name|\", drop_count=\d+)" \
 | regex search!="^(pretypeahead|copybuckets)" \
 | regex search!="^presummarize (tstats=t maintain=\"\" summaryprefix=\"[^\"]+\"|maintain=\"%22SUMMARY_ID%22%2C%22EARLIEST_TIME%22%2C%22REMOTE_SEARCH%22%2C%22NORM_SUMMARY_ID%22%2C%22NORM_REMOTE_SEARCH%22%0A\" summaryprefix=\"[^\"]+\")\s*$" \
@@ -5366,7 +5366,7 @@ index=_internal `indexerhosts` sourcetype=splunkd_remote_searches source="/opt/s
 | addinfo \
 | rename info_max_time AS _time \
 | fields - info_* \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix search_head, search_head_cluster, indexer_cluster, type, user")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix search_head, search_head_cluster, indexer_cluster, type, user```
 
 [IndexerLevel - RemoteSearches Indexes Stats]
 action.email.useNSSubject = 1
@@ -5380,8 +5380,8 @@ display.general.type = statistics
 enableSched = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to determine index access via the remote_searches.log file, useful for when you cannot see the audit logs of all incoming search heads")`\
-    index=_internal sourcetype=splunkd_remote_searches source="/opt/splunk/var/log/splunk/remote_searches.log" terminated: OR closed: `comment("Note that TERM(starting) has the apiStartTime, apiEndTime stats, but lacks the useful stats from a search that is complete. Also note that on indexers scan_count=events_count (in my testing). Finally the elapsedTime sometimes failed to auto-extract, perhaps due to length...")` \
+search = ```Attempt to determine index access via the remote_searches.log file, useful for when you cannot see the audit logs of all incoming search heads```\
+    index=_internal sourcetype=splunkd_remote_searches source="/opt/splunk/var/log/splunk/remote_searches.log" terminated: OR closed: ```Note that TERM(starting) has the apiStartTime, apiEndTime stats, but lacks the useful stats from a search that is complete. Also note that on indexers scan_count=events_count (in my testing). Finally the elapsedTime sometimes failed to auto-extract, perhaps due to length...``` \
 | rex "(?s) elapsedTime=(?P<elapsedTime>[0-9\.]+), search='(?P<search>.*?)(', savedsearch_name|\", drop_count=\d+)" \
 | regex search!="^(pretypeahead|copybuckets)" \
 | rex "drop_count=[0-9]+, scan_count=(?P<scan_count>[0-9]+)" \
@@ -5395,14 +5395,14 @@ search = `comment("Attempt to determine index access via the remote_searches.log
 | eval subsearch=if(isnull(subsearch),"",subsearch) \
 | eval prepipe = prepipe . " " . subsearch \
 | eval search=prepipe \
-| search `comment("The (index=* OR index=_*) index=<specific index> is a common use case for enterprise security, also some individuals like doing a similar trick so remove the index=*... as this is not a wildcard index search")` \
+| search ```The (index=* OR index=_*) index=<specific index> is a common use case for enterprise security, also some individuals like doing a similar trick so remove the index=*... as this is not a wildcard index search``` \
 | rex field=search "(?P<esstylewildcard>\(\s*index=\*\s+OR\s+index=_\*\s*\))" \
 | rex mode=sed field=search "s/search index=\s*\S+\s+index\s*=/search index=/" \
-| search `comment("Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements")` \
+| search ```Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements``` \
 | rex field=search "(?s)(NOT\s+index(\s*=\s*|::)[^ ]+)|(NOT\s+\([^\)]+\))|(index(\s*=\s*|::)(?P<indexregex>[\*A-Za-z0-9-_]+))" max_match=50 \
 | rex field=search "(?s)(NOT\s+index(\s*=\s*|::)[^ ]+)|(NOT\s+\([^\)]+\))|(index(\s*=\s*|::)\"?(?P<indexregex2>[\*A-Za-z0-9-_]+))" max_match=50 \
 | rex field=search "\s+(?P<skipping>\.\.\.\{skipping \d+ bytes\}\.\.\.)" \
-| search `comment("If skipping is in the logs as in index=abc- ...{skipping 46464 bytes}..., then drop the last index found in the regex as it is likely invalid")` \
+| search ```If skipping is in the logs as in index=abc- ...{skipping 46464 bytes}..., then drop the last index found in the regex as it is likely invalid``` \
 | eval indexregex=if(isnotnull(skipping),mvindex(indexregex,0,-2),indexregex) \
 | eval indexregex2=if(isnotnull(skipping),mvindex(indexregex2,0,-2),indexregex2) \
 | eval indexes=mvappend(indexregex,indexregex2) \
@@ -5421,7 +5421,7 @@ search = `comment("Attempt to determine index access via the remote_searches.log
 | eval type=if(isnotnull(presummarize),"acceleration",type) \
 | eval search_head_cluster=`search_head_cluster` \
 | eval indexer_cluster=`indexer_cluster_name(host)` \
-| search `comment("If you use the TERM(starting) you get the apiStartTime/apiEndTime, or you could join them in stats or similar...however this works to obtain which indexes are used. Note that you would need to build something similar to 'SearchHeadLevel - Search Queries summary non-exact match' to be able to translate the wildcards into something more useful, but there would be a lot of guesswork involved if you do not have usernames+server names+roles...(which is why audit logs work better for this)")`\
+| search ```If you use the TERM(starting) you get the apiStartTime/apiEndTime, or you could join them in stats or similar...however this works to obtain which indexes are used. Note that you would need to build something similar to 'SearchHeadLevel - Search Queries summary non-exact match' to be able to translate the wildcards into something more useful, but there would be a lot of guesswork involved if you do not have usernames+server names+roles...(which is why audit logs work better for this)```\
 | rex "search_rawdata_bucketcache_error=[^,]+, search_rawdata_bucketcache_miss=(?P<cache_rawdata_miss>[^,]+), search_index_bucketcache_error=[^,]+, search_index_bucketcache_hit=(?P<cache_index_hit>[^,]+), search_index_bucketcache_miss=(?P<cache_index_miss>[^,]+), search_rawdata_bucketcache_hit=(?P<cache_rawdata_hit>[^,]+), search_rawdata_bucketcache_miss_wait=(?P<cache_rawdata_miss_wait>[^,]+), search_index_bucketcache_miss_wait=(?P<cache_index_miss_wait>[^,]+)" \
 | `base64decode(base64appname)` \
 | eval app3="N/A" \
@@ -5435,7 +5435,7 @@ search = `comment("Attempt to determine index access via the remote_searches.log
 | rename info_max_time AS _time \
 | fields - info_* \
 | eval short="False" \
-| search `comment("| mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, indexer_cluster, type, user, indexes, multi, app, short. If using Splunk 8.0.x delete the below lines and use mcollect, if not you can use summary indexing with metrics")` \
+| search ```| mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, indexer_cluster, type, user, indexes, multi, app, short. If using Splunk 8.0.x delete the below lines and use mcollect, if not you can use summary indexing with metrics``` \
 | rename * AS platform_stats.remote_searches.per_index.exact.* \
 | rename platform_stats.remote_searches.per_index.exact.search_head_cluster AS search_head_cluster platform_stats.remote_searches.per_index.exact.indexer_cluster AS indexer_cluster, platform_stats.remote_searches.per_index.exact.type AS type, platform_stats.remote_searches.per_index.exact.user AS user, platform_stats.remote_searches.per_index.exact.indexes AS indexes, platform_stats.remote_searches.per_index.exact.multi AS multi, platform_stats.remote_searches.per_index.exact.short AS short, platform_stats.remote_searches.per_index.exact.app AS app \
 | fields - prefix
@@ -5453,7 +5453,7 @@ enableSched = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest "/servicesNS/-/-/saved/searches" count=0 `splunkadmins_restmacro` f=search f=realtime_schedule f=eai:* f=action.summary_index \
-| search `comment("Find reports running summary indexing that are not scheduled using continuous scheduling (realtime_schedule=0)")`\
+| search ```Find reports running summary indexing that are not scheduled using continuous scheduling (realtime_schedule=0)```\
 | where realtime_schedule=1 \
 | rex field=search "(?s)\|\s*(?P<command>mcollect|meventcollect|collect)\s+" \
 | where isnotnull(command) OR 'action.summary_index'==1 \
@@ -5472,9 +5472,9 @@ display.general.type = statistics
 enableSched = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = index=_audit info=granted search_id!="'rsa_*" `comment("Report on searches dispatched with owner (not user) setting and the search involved")` \
+search = index=_audit info=granted search_id!="'rsa_*" ```Report on searches dispatched with owner (not user) setting and the search involved``` \
 | rex "info=granted , search_id='(?P<search_id>[^']+)" \
-| search `comment("A regex that includes what a userid looks like within your company will likely be faster than trying to exclude all alternatives like the below...")` \
+| search ```A regex that includes what a userid looks like within your company will likely be faster than trying to exclude all alternatives like the below...``` \
 | regex search_id!="^((subsearch_)?\d|rt_|(subsearch_)?scheduler|SummaryDirector_|ta_|RemoteStorageRetrieveIndexes_|md_|subsearch_searchparsetmp| alertsmanager_|subsearch_AlertActionsRequredFields|alertsmanager_|sd_)" \
 | rex field=search_id "(?P<from>[^_]+)((_(?P<base64owner>[^_]+))|(__(?P<owner>[^_]+)))" \
 | `base64decode(base64owner)` \
@@ -5749,7 +5749,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("A retrospective alert to advise that the Splunk process was terminated and restarted multiple times and this likely requires further investigation")` \
+search = ```A retrospective alert to advise that the Splunk process was terminated and restarted multiple times and this likely requires further investigation``` \
 index=`splunkadmins_wineventlog_index` sourcetype=WinEventLog:Application OR sourcetype=XmlWinEventLog:Application SourceName="Application Error" splunk \
 | stats count, earliest(_time) AS firstSeen, latest(_time) AS lastSeen by host, Faulting_application_path \
 | where count > `splunkadmins_unexpected_term_count` \
@@ -5772,9 +5772,9 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("A retrospective alert to advise that the Splunk process was terminated and this likely requires further investigation")` \
+search = ```A retrospective alert to advise that the Splunk process was terminated and this likely requires further investigation``` \
 index=_internal index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) \
-`comment("Expecting 'FATAL ProcessRunner - Unexpected EOF from process runner child!' OR 'ProcessRunner - helper process seems to have died (child killed by signal 9: Killed)!' which can occur by the OOM killer for example")` \
+```Expecting 'FATAL ProcessRunner - Unexpected EOF from process runner child!' OR 'ProcessRunner - helper process seems to have died (child killed by signal 9: Killed)!' which can occur by the OOM killer for example``` \
 "Unexpected EOF from process runner" OR "helper process seems to have died" \
 | eval event_message=coalesce(event_message,message) \
 | stats count, earliest(_time) AS firstSeen, latest(_time) AS lastSeen, values(event_message) AS event_message by host\
@@ -5797,7 +5797,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The caller=strings_metadata relates to maxMetaEntries in the indexes.conf.spec file, at the time of writing it is the maximum number of unique lines in .data files in a bucket, once exceeded it is rolled so this may cause premature bucket rolling")` \
+search = ```The caller=strings_metadata relates to maxMetaEntries in the indexes.conf.spec file, at the time of writing it is the maximum number of unique lines in .data files in a bucket, once exceeded it is rolled so this may cause premature bucket rolling``` \
 index=_internal `indexerhosts` sourcetype=splunkd `splunkadmins_splunkd_source` caller=strings_metadata \
 | cluster showcount=true \
 | stats sum(entries) AS count, values(host) AS hosts, values(event_message) AS event_messages by idx
@@ -5843,7 +5843,7 @@ request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = index=_internal sourcetype=splunkd `splunkadmins_splunkd_source` "Queue for group" "has begun dropping" OR "has stopped dropping events" `heavyforwarderhosts` OR `indexerhosts` \
 | rex "group\s+(?P<group>\S+).*?(?P<state>(stopped|begun))" \
-| search `comment("instead of sort 0 _time, | reverse may work in some scenarios...")` \
+| search ```instead of sort 0 _time, | reverse may work in some scenarios...``` \
 | sort 0 _time\
 | streamstats current=f global=f window=1 values(state) AS prev_state, min(_time) AS start by host, group\
 | search state="stopped" AND prev_state="begun"\
@@ -5868,7 +5868,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = index=_internal `splunkadmins_metrics_source` TERM(name=pipelineinputchannel) new_channels sourcetype=splunkd `comment("As per https://answers.splunk.com/answers/825663/why-did-ingestion-slow-way-down-after-i-added-thou.html , having too many channels created/removed can cause issues")`\
+search = index=_internal `splunkadmins_metrics_source` TERM(name=pipelineinputchannel) new_channels sourcetype=splunkd ```As per https://answers.splunk.com/answers/825663/why-did-ingestion-slow-way-down-after-i-added-thou.html , having too many channels created/removed can cause issues```\
 | bin _time span=1m\
 | stats avg(new_channels) AS avg_new_channels avg(removed_channels) AS avg_removed_channels by host, _time\
 | where avg_new_channels>5000 AND avg_removed_channels>1000 \
@@ -5895,7 +5895,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Ignoring path is quite literal, the TailReader process will ignore the said log file and never index it. If you want the said file indexed then you will need to create a sourcetype for it...")` \
+search = ```Ignoring path is quite literal, the TailReader process will ignore the said log file and never index it. If you want the said file indexed then you will need to create a sourcetype for it...``` \
 index=_internal sourcetype=splunkd (`splunkadmins_splunkd_source`) OR (`splunkadmins_splunkuf_source`) "Ignoring path" earliest=-24h `splunkadmins_tailreader_ignorepath` \
 | regex path!="\.\d$" \
 | stats latest(_time) AS lastSeen, earliest(_time) AS firstSeen, last(_raw) AS lastmessage by host, path \
@@ -5923,14 +5923,14 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest `splunkadmins_restmacro` /servicesNS/-/-/data/ui/views timeout=600 \
-| search `comment("While it will be more accurate to look at the audit logs to see who is using all time in the earliest/latest fields, this is an attempt to identify dashboards that do not have a <earliest> field *or* an earliest= within the search query. There is likely room for improvement in this query but it appears to work so far...")` \
+| search ```While it will be more accurate to look at the audit logs to see who is using all time in the earliest/latest fields, this is an attempt to identify dashboards that do not have a <earliest> field *or* an earliest= within the search query. There is likely room for improvement in this query but it appears to work so far...``` \
 | search NOT ((eai:acl.app="splunk_simple_xml_examples" OR eai:acl.app=splunk_app_windows_infrastructure) AND eai:acl.owner="nobody") \
 | rex field=eai:data "(?s)<input\s*(?P<time_input>[^>]*type\s*=\s*\"time[^>]+)>" \
 | eval has_global_time_picker=if(match(time_input, "token\s*="),null(),if(isnotnull(time_input),true(),null())) \
 | where isnull(has_global_time_picker) \
 | rex field=eai:data max_match=500 "(?s)<searc(?P<base>h[^>]*)>(?P<search>.*?)</search>" \
 | eval combined = mvzip(base, search, "%%%%%%%%%%") \
-| search `comment("From the data, find tokens, if the token includes an earliest= value, find it and store it into token_name2")` \
+| search ```From the data, find tokens, if the token includes an earliest= value, find it and store it into token_name2``` \
 | multireport \
     [| xpath field=eai:data "//input" outfield=input \
     | eval input=mvfilter(match(input,"token\s*=\s*")) \
@@ -5960,7 +5960,7 @@ search = | rest `splunkadmins_restmacro` /servicesNS/-/-/data/ui/views timeout=6
 | regex search!="(?s)<earliest>.*?</earliest>"\
 | rex field=query "\$(?P<token>[^\$]+)\$" max_match=50\
 | nomv time_tokens\
-| search `comment("If you run pre-Splunk 8.0.x then you will need to mvexpand at this point instead, then perhaps a stats values(*) AS * by eai:acl.app, eai:acl.sharing, label, title, updated, eai:acl.owner or similar...")` \
+| search ```If you run pre-Splunk 8.0.x then you will need to mvexpand at this point instead, then perhaps a stats values(*) AS * by eai:acl.app, eai:acl.sharing, label, title, updated, eai:acl.owner or similar...``` \
 | eval matches=mvmap(token,if(match(time_tokens,"(^|\s+)" . token . "(\s+|$)"),"true",null()))\
 | where isnull(matches)\
 | stats count, values(search) AS search_examples by eai:acl.app, eai:acl.sharing, label, title, updated, eai:acl.owner\
@@ -5980,7 +5980,7 @@ display.general.type = statistics
 enableSched = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Search the audit logs for any search that does not have a earliest time set. Note search_et is not set for canceled/failed status so deal with this later...As per the comments on https://ideas.splunk.com/ideas/E-I-49 this can miss the _index_earliest flag passed in via API but it works for most cases")` \
+search = ```Search the audit logs for any search that does not have a earliest time set. Note search_et is not set for canceled/failed status so deal with this later...As per the comments on https://ideas.splunk.com/ideas/E-I-49 this can miss the _index_earliest flag passed in via API but it works for most cases``` \
 index=_audit sourcetype=audittrail search_id!="rsa_*" `searchheadhosts` info="failed" OR info="completed" OR info="canceled" search=* search_et="N/A" `splunkadmins_audit_alltime` \
 | regex search="(?s)^'\s*\|?search\s+" \
 | regex search_id!="^'subsearch_" \
@@ -6107,8 +6107,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Look for dispatch problems in the splunk_search_messages sourcetype")` \
-`comment("This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1")`\
+search = ```Look for dispatch problems in the splunk_search_messages sourcetype``` \
+```This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1```\
 index=_internal `searchheadhosts` orig_component="DispatchThread" sourcetype=splunk_search_messages \
 | cluster t=0.4 showcount=true \
 | table _time, cluster_count, _raw \
@@ -6135,7 +6135,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Detect searches aborted by WLM rules and using the sid find the details of the search, provide the details so this could be used with an application like sendresults for automated user notification of rule violation")` \
+search = ```Detect searches aborted by WLM rules and using the sid find the details of the search, provide the details so this could be used with an application like sendresults for automated user notification of rule violation``` \
 index=_internal "The search" "was aborted" `searchheadhosts` sourcetype=splunkd `splunkadmins_splunkd_source` \
 | rex "WorkloadManager (?:\[\d+ \w+] )?- The search (?P<search_id>[^ ]+)" \
 | eval search_id="'" . search_id . "'" \
@@ -6166,7 +6166,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This warning when occurring repetitively tends to indicate some kind of issue that will require the file to be manually removed. For example a zero sized metadata file that cannot be reaped by the dispatch reaper")` \
+search = ```This warning when occurring repetitively tends to indicate some kind of issue that will require the file to be manually removed. For example a zero sized metadata file that cannot be reaped by the dispatch reaper``` \
 index=_internal sourcetype=splunkd `splunkadmins_splunkd_source` WARN DispatchSearchMetadata \
 | stats count by event_message, host \
 | where count>100 \
@@ -6194,7 +6194,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This warning when occurring repetitively tends to indicate some kind of issue that will require the file to be manually removed. For example a zero sized metadata file that cannot be reaped by the dispatch reaper")` \
+search = ```This warning when occurring repetitively tends to indicate some kind of issue that will require the file to be manually removed. For example a zero sized metadata file that cannot be reaped by the dispatch reaper``` \
 index=_internal `indexerhosts` source=*remote_searches.log terminated: OR closed: \
 | regex search!="^(pretypeahead|copybuckets)" \
 | rex "(?s) elapsedTime=(?P<elapsedTime>[0-9\.]+), search='(?P<search>.*?)(', savedsearch_name|\", drop_count=\d+)" \
@@ -6229,7 +6229,7 @@ enableSched = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 schedule_window = 30
-search = `comment("Search the audit logs to find the RMD5 entries and record them into a lookup file")` index=_audit info=completed RMD5* search_id!="'rsa_*"\
+search = ```Search the audit logs to find the RMD5 entries and record them into a lookup file``` index=_audit info=completed RMD5* search_id!="'rsa_*"\
 | regex search_id!="^'subsearch_"\
 | rex field=search_id "(?P<RMDvalue>RMD5[^_]+)"\
 | stats values(savedsearch_name) AS savedsearch_name by RMDvalue\
@@ -6376,18 +6376,18 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to find various messages in the splunk_search_messages which are related to scheduled searches or dashboards which may require correcting, ignore ad-hoc searches")`\
-`comment("This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1")`\
+search = ```Attempt to find various messages in the splunk_search_messages which are related to scheduled searches or dashboards which may require correcting, ignore ad-hoc searches```\
+```This does require the limits.conf log_search_messages=true setting to be enabled to work, if below version 9.1```\
         index=_internal `searchheadhosts` sourcetype=splunk_search_messages "MultiValueProcessor" OR "SearchStatusEnforcer" OR "SearchOperator" OR "SQL" OR "truncated" OR "script" OR "KV" OR "External" OR "outputcsv" OR "reset" OR "match_limit" OR authorized OR terminated OR depth_limit OR driver OR dbx OR command OR java OR reading OR training OR DensityFunction OR (TERM(in-memory) limit) OR terminated OR invalid OR (missing NOT orig_component="SummaryIndexProcessor") OR Unable OR reset OR AutoLookupDriver OR ImportError OR jdbc OR SSLError OR TERM(code=) OR REST OR SearchParser \
 OR (missing NOT orig_component="SummaryIndexProcessor") OR Unable OR ("Can't" "parse") OR "field(s) do not exist" OR ("setting" "deprecated") OR ("ignored" "missing") OR "Dropping field(s) with too many distinct values" OR "does not exist" OR orig_component="TsidxStats" OR orig_component="SearchOrchestrator" OR orig_component="ForeachProcessor" OR orig_component="SearchPhaseGenerator" OR orig_component="SearchProcessor" OR HTTPError\
-`comment("Potential issues that are not included SearchEvaluatorBasedExpander, shows if eventtypes/tags are disabled/do not exist or similar")` `splunkadmins_searchmessages_user_1` \
+```Potential issues that are not included SearchEvaluatorBasedExpander, shows if eventtypes/tags are disabled/do not exist or similar``` `splunkadmins_searchmessages_user_1` \
     NOT "KV Store lookup table is empty" NOT "message=Restricting results of the \"rest\" operator to the local instance because you do not have the" NOT "Failed to fetch REST endpoint uri=https://127.0.0.1:8089/services/data/indexes-extended/" NOT "Unexpected status for to fetch REST endpoint uri=https://127.0.0.1:8089/services/data/indexes-extended" NOT "Failed to fetch REST endpoint uri=https://127.0.0.1:8089/services/data/indexes" NOT "The REST request on the endpoint URI /services/data/indexes" NOT "message=Could not locate the time (_time) field on some results returned from the external search command 'curl'" NOT "message=Found no results to append to collection" NOT "The search you ran returned a number of fields that exceeded the current indexed field extraction limit" NOT "message=Found no results to append to collection" NOT "The search you ran returned a number of fields that exceeded the current indexed field extraction limit" NOT "Connection failed with Read Timeout" NOT "message=Search was canceled" NOT "message=Search auto-canceled" NOT "The timewrap command is designed to work on the output of timechart" NOT ("Field" "does not exist") NOT "Connection reset by peer" NOT "Reading error while waiting for peer" NOT "Restricting results of the \"rest\" operator to the local instance" NOT "occur when processing chunks in running lookup command" NOT "because KV Store initialization has not completed yet" NOT "The following options were specified but have no effect" NOT "https://127.0.0.1:8089/servicesNS/nobody/SA-ITOA/itoa_interface/generate_entity_filter" NOT "because KV Store status is currently unknown" NOT ("https://127.0.0.1:8089/services/server/introspection/kvstore/collectionstats" OR "https://127.0.0.1:8089/services/server/sysinfo" ("exists in the REST API" OR "Forbidden")) NOT ("https://127.0.0.1:8089/services/data/indexes-extended" OR "https://127.0.0.1:8089/services/data/indexes" ("Not Found" OR "exists in the REST API")) NOT "Only the last one will appear, and previous" NOT ("Field extractor" "unusually slow") \
     NOT "Unable to distribute to peer" NOT (Eventtype "does not exist or is disabled") NOT "Unable to find tag" NOT "reference cycle in the lookup configuration" NOT "Search cancellation requested." NOT "because KV Store is shutting down" NOT "The 'require' command received zero events or results"  NOT "Bundle replication to peer named"\
-`comment("OR TERM(filters) was originally in the query, but the error \"Search filters specified using splunk_server/splunk_server_group do not match any search peer.\" can occur anytime there are zero results, even if the splunk_server=/splunk_server_group= was not the cause of the issue, therefore this particular warning is not useful in it's current form...")` \
+```OR TERM(filters) was originally in the query, but the error \"Search filters specified using splunk_server/splunk_server_group do not match any search peer.\" can occur anytime there are zero results, even if the splunk_server=/splunk_server_group= was not the cause of the issue, therefore this particular warning is not useful in it's current form...``` \
 | regex sid!="^(rt_)?(ta_)?(subsearch_)*(nested_[^_]+_)?\d+" \
 | `search_type_from_sid(sid)`\
 | eval type=case(from=="scheduler","scheduled",from=="SummaryDirector","acceleration",isnotnull(searchname),"dashboard",1=1,"ad-hoc") \
-| search `comment("Depending on how noisy this alert is you may wish to add type!=dashboard using the macro splunkadmins_searchmessages_user_2")` NOT ("command=\"predict\", Too few data points" AND type="dashboard") NOT (type="dashboard" "https://127.0.0.1:8089/servicesNS/-/-/admin/file-explorer") NOT (type="dashboard" "https://127.0.0.1:8089/servicesNS/-/-/admin/file-explorer" OR "The specified span would result in too many") NOT (type="ad-hoc" "DAG Execution Exception: Search has been cancelled") `splunkadmins_searchmessages_user_2` \
+| search ```Depending on how noisy this alert is you may wish to add type!=dashboard using the macro splunkadmins_searchmessages_user_2``` NOT ("command=\"predict\", Too few data points" AND type="dashboard") NOT (type="dashboard" "https://127.0.0.1:8089/servicesNS/-/-/admin/file-explorer") NOT (type="dashboard" "https://127.0.0.1:8089/servicesNS/-/-/admin/file-explorer" OR "The specified span would result in too many") NOT (type="ad-hoc" "DAG Execution Exception: Search has been cancelled") `splunkadmins_searchmessages_user_2` \
 | `base64decode(base64username)` \
 | `base64decode(base64appname)` \
 | eval app3="N/A" \
@@ -6426,12 +6426,12 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to find various messages in the splunk_search_messages which are related to scheduled searches or dashboards which may require correcting, ignore ad-hoc searches")`\
-`comment("This does require the limits.conf log_search_messages=true setting to be enabled to work. If below version 9.1")`\
+search = ```Attempt to find various messages in the splunk_search_messages which are related to scheduled searches or dashboards which may require correcting, ignore ad-hoc searches```\
+```This does require the limits.conf log_search_messages=true setting to be enabled to work. If below version 9.1```\
     index=_internal `searchheadhosts` sourcetype=splunk_search_messages (Unable peer) OR bundles OR "bundle replication" OR corrupt OR connecting OR ReadWrite OR Socket OR Timed OR incomplete OR cleanly OR Timeout OR Timed OR process OR insufficient OR (bucket failed) OR "occur when processing chunks in running lookup command" OR "because KV Store status is currently unknown" OR (File line) OR (SearchPipelineExecutor NOT "exceeded configured match_limit") OR S2BucketCache OR DistributedSearchResultCollectionManager OR ("Field extractor" "unusually slow") OR "line *:" OR GeoIPProvider OR "restricting search to" OR ExternalProvider NOT "Unable to find tag" NOT "Unable to parse the search" NOT ("Eventtype" "does not exist") NOT "Error in 'outputlookup' command: You have insufficient privileges" NOT "insufficient data in ITSI summary index for policies" \
 NOT ("Failed to fetch REST endpoint" "/services/data/indexes-extended" "Check that the URI path provided exists in the REST API" OR "Not Found")\
 `splunkadmins_searchmessages_admin_1`\
-    `comment("Potential issues that are not included SearchEvaluatorBasedExpander, shows if eventtypes/tags are disabled/do not exist or similar")` \
+    ```Potential issues that are not included SearchEvaluatorBasedExpander, shows if eventtypes/tags are disabled/do not exist or similar``` \
 NOT ("Failed to fetch REST endpoint" "/services/data/indexes-extended" "Check that the URI path provided exists in the REST API" OR "Not Found") NOT "Found no results to append to collection"\
 `splunkadmins_searchmessages_admin_1`\
 | `search_type_from_sid(sid)`\
@@ -6475,29 +6475,29 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = index=_internal `splunkenterprisehosts` `splunkadmins_splunkd_log_messages` \
-`comment("OR (TERM(DateParserVerbose) TERM(consecutive)) was previously included in the splunkd.log section but the message about unretrievable data does not appear to be accurate, Splunk auto-increments the timestamp by 1s every 200K events so this is not an issue as such...")` \
+```OR (TERM(DateParserVerbose) TERM(consecutive)) was previously included in the splunkd.log section but the message about unretrievable data does not appear to be accurate, Splunk auto-increments the timestamp by 1s every 200K events so this is not an issue as such...``` \
     (sourcetype=splunkd (`splunkadmins_splunkd_source`) WARN OR ERROR MongoModificationsTracker OR TERM(SearchOperator:kv) OR AuditTrailManager OR IniFile OR GetBundleListTransaction OR GenericConfigKeyHandler OR AuthorizationManager OR GetRemoteAuthToken OR DistributedPeer OR (Archiver Permission) OR GetIndexListTransaction OR (DistributedPeerManager Timeout OR TERM(status=Down)) OR CalcFieldProcessor OR FieldAliaser OR (SearchScheduler OR DispatchManager "minimum free disk space") OR ApplicationUpdater OR (ScopedLDAPConnection NOT "Might indicate slow ldap server" NOT "Converting non-UTF-8 value to") OR regexExtractionProcessor OR (ProcessTracker NOT ConfMetrics) OR ConfReplication OR TailingProcessor OR "Invalid cron_schedule" OR "Persistent file" OR "Too many indexes" OR (UserManagerPro Strategy) OR SearchProcessMemoryTracker OR SSLOptions OR (SHCRepJob misspelled) OR PivotEvaluator OR PropertiesMap OR HTTPAuthManager OR X509Verify OR FilesystemChangeWatcher OR PropsKeyHandler OR IndexProcessor OR BundleArchiver OR (ApplicationManager NOT "Skipping update check for app id" NOT "This is expected if you push an app from the cluster master") OR ISplunkDispatch OR TcpInputConfig OR (CollectionConfHandler Bad OR reload) OR SLConstants OR TERM(AdminHandler:AuthenticationHandler) OR (DispatchManager NOT (failedtostart OR quota OR QUEUED OR concurrency OR concurrently)) OR KVStoreBulletinBoardManager OR CMRestIndexerDiscoveryHandler\
 OR KVStoreConfigurationProvider OR LMMasterRestHandler OR LMHttpUtil OR (DatabaseDirectoryManager Detecting) OR (No space NOT SHCRepJob NOT DispatchManager) OR (baseline configuration replicating) OR LMTracker OR IndexerDiscoveryHeartbeatThread OR ModularUtility OR ScriptRestHandler OR (component IN (S3Client, RetryableClientTransaction) (TERM(success=N)  OR ("statusCode=") NOT TERM(statusCode=404) NOT TERM(retry=Y))) \
 OR WorkloadConfig OR "WARN  loader" OR "ERROR loader" OR (TERM(AdminHandler:AuthenticationHandler) reasonable)\
 OR (KVStoreLookup OR KVStoreProvider OR SingleLookupDriver OR outputcsv OR TERM(SearchOperator:inputcsv) NOT "You have insufficient privileges" NOT "KV Store initialization" NOT "KV Store is shutting down" NOT "Found no results" NOT "lookup context" NOT "searchparsetmp" NOT "Invalid argument" NOT "must be followed by a search clause") OR ConfigEncryptor OR AesGcm\
 OR GenerationGrabber OR CMSearchHead OR DistHealthFetcher OR SpecFiles OR DeploymentServer OR DistributedPeerManagerHeartbeat OR MongodRunner OR (TERM(DS_DC_Common) NOT "attributes cannot be handled by WebUI" NOT "Attribute unsupported by UI") OR STMgr OR (heartbeat SHCSlave OR SHCMasterHTTPProxy OR failure) OR ServerInfoHandler OR BucketReplicator OR (TcpInputProc Stopping) OR StreamGroup \
 OR (ScriptRunner Killing OR stderr) OR LMStackMgr OR (DatabaseDirectoryManager corrupt) OR (BucketMover exited) OR ("KVStorageProvider" NOT "Result size too large" NOT "Too many rows in result") OR DistributedPeerManager OR (HttpClientRequest NOT "Broken pipe") OR (UserManagerPro NOT "Login failed" NOT "Failed to find ldapuser" NOT "Failed to get ldapuser") OR (component=AutoLoadBalancedConnectionStrategy NOT "Possible duplication" NOT "no raw data") OR AppsDeployHandler OR SHCConfig OR (ClusterMasterControlHandler NOT "No new dry run will be performed") OR RaftSimpleFileStorage \
-OR IConfCache OR (WorkloadManager NOT "Failed to select user provided workload_pool" NOT "trans") OR WorkloadClass OR AdminManagerExternal  OR (SavedSearchAdminHandler NOT ("Unbalanced quotes", "Invalid cron_schedule", "Invalid search id, dispatch directory does not exist", "specifies a macro 'nix_app_index' that cannot be found", "Empty string is not a valid search string", "Cannot change user and/or app context of a report that is embedded")) OR JournalSlice OR PipelineComponent OR IndexConfig OR RawdataHashMarkReader OR ArchiveContext OR DateParser OR TimeoutHeap OR LMStackMgr OR AutoLookupDriver OR (TERM(spatial:PointInPolygonIndex) corruption) OR TERM(IntrospectionGenerator:resource_usage) OR PasswordHandler OR ConfigEncryptor OR AesGcm OR ModularInputs OR component IN (IndexerService,RetireOldS2S,UserManager,regexExtractionProcessor,Regex) OR (IndexingBundleLookupThread `comment("IndexingBundleLookupThread can occur when the transforms.conf has a kvstore but not the collection= so [kvdef] external_type = kvstore fields_list= ... is valid, but without collection= it can throw this error on 8.2.5, if updating via REST to /data/transforms/lookups include external_type/fields_list and collection= in the POST")`) \
-OR (ChunkedExternProcessor `comment("Note ChunkedExternProcessor introduces noise as well as legitimate errors")`) OR (SHCRepJob OR SHCMasterArtifactHandler Reason) OR (ExecProcessor message from NOT InsecureRequestWarning) OR (Crypto Decryption) OR (CacheManagerHandler failure) OR (component=ExecProcessor Errno OR Unexpected OR Expected OR Ignoring NOT InsecureRequestWarning) OR (ConfMetrics NOT "single_action=BASE_INITIALIZE" `comment("more research required on how of if these require tuning, but they likely relate to SHC issues")` ) \
-`comment("included in others alerts: CMMasterProxy, AutoLoadBalancedConnectionStrategy (data duplication/timeouts), ExecProcessor?")` OR (DistributedBundleReplicationManager `comment("This is confirmed as an invalid warning message in Splunk 9")` NOT "Failed to touch bundle=, checksum=0 (manual preparation): No such file or directory") OR (SearchScheduler SearchProcessorException capability) OR (DispatchManager sufficient) OR (SearchScheduler sufficient) OR BundlesUtil OR AwsCredentials OR CMBundleStreamHandler OR (CMMaster Cannot) OR "fd limit" \
-OR (component=SearchProcessRunner NOT "RequireProcessor" NOT "hung up" NOT (log_level=WARN code=111 OR exit=111) NOT (log_level=ERROR "caught exception") `comment("the following are not considered an issue WARN  SearchProcessRunner [37354 PreforkedSearchesManager-0] - preforked process=0/1607321 with search=0/2039381 exited with code=111, ERROR SearchProcessRunner [37354 PreforkedSearchesManager-0] - preforked search=0/2039381 on process=0/1607321 caught exception. completed_searches=2, process_started_ago=15.511, search_started_ago=6.788, search_ended_ago=0.000, total_usage_time=10.580, ERROR SearchProcessRunner [37354 PreforkedSearchesManager-0] - preforked process=0/1607321 died on exception (exit code=111): Error in 'RequireProcessor': The 'require' command received zero events or results; the search will be intentionally stopped")` )\
+OR IConfCache OR (WorkloadManager NOT "Failed to select user provided workload_pool" NOT "trans") OR WorkloadClass OR AdminManagerExternal  OR (SavedSearchAdminHandler NOT ("Unbalanced quotes", "Invalid cron_schedule", "Invalid search id, dispatch directory does not exist", "specifies a macro 'nix_app_index' that cannot be found", "Empty string is not a valid search string", "Cannot change user and/or app context of a report that is embedded")) OR JournalSlice OR PipelineComponent OR IndexConfig OR RawdataHashMarkReader OR ArchiveContext OR DateParser OR TimeoutHeap OR LMStackMgr OR AutoLookupDriver OR (TERM(spatial:PointInPolygonIndex) corruption) OR TERM(IntrospectionGenerator:resource_usage) OR PasswordHandler OR ConfigEncryptor OR AesGcm OR ModularInputs OR component IN (IndexerService,RetireOldS2S,UserManager,regexExtractionProcessor,Regex) OR (IndexingBundleLookupThread ```IndexingBundleLookupThread can occur when the transforms.conf has a kvstore but not the collection= so [kvdef] external_type = kvstore fields_list= ... is valid, but without collection= it can throw this error on 8.2.5, if updating via REST to /data/transforms/lookups include external_type/fields_list and collection= in the POST```) \
+OR (ChunkedExternProcessor ```Note ChunkedExternProcessor introduces noise as well as legitimate errors```) OR (SHCRepJob OR SHCMasterArtifactHandler Reason) OR (ExecProcessor message from NOT InsecureRequestWarning) OR (Crypto Decryption) OR (CacheManagerHandler failure) OR (component=ExecProcessor Errno OR Unexpected OR Expected OR Ignoring NOT InsecureRequestWarning) OR (ConfMetrics NOT "single_action=BASE_INITIALIZE" ```more research required on how of if these require tuning, but they likely relate to SHC issues``` ) \
+```included in others alerts: CMMasterProxy, AutoLoadBalancedConnectionStrategy (data duplication/timeouts), ExecProcessor?``` OR (DistributedBundleReplicationManager ```This is confirmed as an invalid warning message in Splunk 9``` NOT "Failed to touch bundle=, checksum=0 (manual preparation): No such file or directory") OR (SearchScheduler SearchProcessorException capability) OR (DispatchManager sufficient) OR (SearchScheduler sufficient) OR BundlesUtil OR AwsCredentials OR CMBundleStreamHandler OR (CMMaster Cannot) OR "fd limit" \
+OR (component=SearchProcessRunner NOT "RequireProcessor" NOT "hung up" NOT (log_level=WARN code=111 OR exit=111) NOT (log_level=ERROR "caught exception") ```the following are not considered an issue WARN  SearchProcessRunner [37354 PreforkedSearchesManager-0] - preforked process=0/1607321 with search=0/2039381 exited with code=111, ERROR SearchProcessRunner [37354 PreforkedSearchesManager-0] - preforked search=0/2039381 on process=0/1607321 caught exception. completed_searches=2, process_started_ago=15.511, search_started_ago=6.788, search_ended_ago=0.000, total_usage_time=10.580, ERROR SearchProcessRunner [37354 PreforkedSearchesManager-0] - preforked process=0/1607321 died on exception (exit code=111): Error in 'RequireProcessor': The 'require' command received zero events or results; the search will be intentionally stopped``` )\
 OR component=Saml OR component=FileClassifierManager OR component=HttpPubSubConnection OR component=KVStoreBackupRestore OR component=TelemetryHandler OR component=AdminManagerValidation OR component IN (RfsDestination, RfsOutputProcessor) OR component IN (AuthenticationManagerSplunk, RetireOldS2S, JsonWebTokenHandle, AwsSDK, IndexerIf, Application) OR "exited with status code" OR "Error in 'script'" OR "Script execution failed" \
 ``` this is covered by "SearchHeadLevel - KVStore Or Conf Replication Issues Are Occurring" as well ``` OR component=ConfReplicationThread OR (component=DiskMon AND log_level=ERROR) ``` this can be a little bit noisy, if related to the indexers perhaps more eviction padding will help? ``` OR (component=SHCMasterHTTPProxy "captain as down") OR component=ServerInfoHandler OR component=SHCConfig OR "active replication count &gt;= max_peer_rep_load" OR (component=SearchScheduler NOT "maximum disk usage quota" NOT "based on their role quota" NOT "Alert script execution failed" NOT "Alert script returned error code" ``` these last two should be covered by other alerts```) OR "Application does not exist" OR "account has expired" OR "You do not have a role" OR component=JsonWebTokenHandler OR component=SearchLogCopier OR component=BulletinBoard OR component=RfsOutputProcessor* ``` note this can be missed with the shutdown macro ``` OR setManualDetention OR component=InstalledFilesHashChecker OR component=PropertiesMap OR component=TcpOutputFd OR component IN (HTTPServer, HttpInputServer)\
- NOT ("Configuration from app" "does not support reload") `comment("This is a harmless error message, tsidx is optimized after this error appears")` `comment("txn close did not succeed completely while flushing and closing a tsidx file rc=-8. Can be self-repaired in some cases but not all, so you may need to check on the bucket to see if it's an issue. It can relate to large >20MB+ events with slower IO for example")` \
+ NOT ("Configuration from app" "does not support reload") ```This is a harmless error message, tsidx is optimized after this error appears``` ```txn close did not succeed completely while flushing and closing a tsidx file rc=-8. Can be self-repaired in some cases but not all, so you may need to check on the bucket to see if it's an issue. It can relate to large >20MB+ events with slower IO for example``` \
  NOT "Rounded off to 100% to handle the interval drift" ) NOT ("CacheManager Cannot determine amount of free space for partition of dir" "No such file or directory") NOT ("S2SFileReceiver" "No such file or directory") NOT ("KVStorageProvider" "Insert data failed" "already exists") NOT ("SearchOperator:inputcsv" "might contain invalid operators") NOT ("INFO" "BucketReplicator" "successful" OR "Starting replication of bucket" OR "event=finishBucketReplication" OR "event=localReplicationFinished" OR "event=replicationFinished" OR "event=startBucketReplication") NOT ("INFO" "SpecFiles" "Found external scheme definition for stanza") \
  NOT ("INFO" "IndexProcessor" "removing replication target temp") NOT ("INFO" "ModularInputs" "Endpoint argument settings for") \
-`comment("these may require more investigation. Ignoring for now Aug 2022")` NOT ("ERROR CacheManager" "No such file or directory") NOT ("ERROR BucketReplicator" "The bucket may have frozen") NOT ("BucketReplicator" "Failed to check the hotness of bucketId") \
+```these may require more investigation. Ignoring for now Aug 2022``` NOT ("ERROR CacheManager" "No such file or directory") NOT ("ERROR BucketReplicator" "The bucket may have frozen") NOT ("BucketReplicator" "Failed to check the hotness of bucketId") \
  OR (sourcetype=scheduler source=*scheduler.log AlertNotifier WARN) \
- OR (sourcetype=splunkd (`splunkadmins_splunkd_source`) INFO (IndexWriter paused `comment("May relate to maxConcurrentOptimizes in indexes.conf or perhaps maxRunningProcessGroups or spikes in data-per indexer")`) OR (TERM(event=reclaimMemory) IndexProcessor OR StreamingBucketBuilder `comment("May relate to memPoolMB / maxMemMB setting in indexes.conf or the IndexWriter getting paused. However data balance (too much MB/s of ingestion on a single indexer/uneven balance appears to cause this too)")`)) \
-| search `comment("ignore shutdown times to remove errors that relate to shutdowns, note this may remove some legitimate alerts as well")` AND NOT [ `splunkadmins_shutdown_time_by_period(splunkenterprisehosts,60,60,10)` ] \
+ OR (sourcetype=splunkd (`splunkadmins_splunkd_source`) INFO (IndexWriter paused ```May relate to maxConcurrentOptimizes in indexes.conf or perhaps maxRunningProcessGroups or spikes in data-per indexer```) OR (TERM(event=reclaimMemory) IndexProcessor OR StreamingBucketBuilder ```May relate to memPoolMB / maxMemMB setting in indexes.conf or the IndexWriter getting paused. However data balance (too much MB/s of ingestion on a single indexer/uneven balance appears to cause this too)```)) \
+| search ```ignore shutdown times to remove errors that relate to shutdowns, note this may remove some legitimate alerts as well``` AND NOT [ `splunkadmins_shutdown_time_by_period(splunkenterprisehosts,60,60,10)` ] \
 | eval search_head=host \
 | eval search_head_cluster=`search_head_cluster` \
-| search `comment("Exclude time periods where shutdowns were occurring. While this makes the alert less nosiy it removes some legitimate errors too")` AND NOT \
+| search ```Exclude time periods where shutdowns were occurring. While this makes the alert less nosiy it removes some legitimate errors too``` AND NOT \
     [ `splunkadmins_shutdown_time_by_shc(searchheadhosts,60,60)`] \
 | eval message=coalesce(message,event_message) \
 | rex mode=sed field=message "s/^\([^\)]+\)\s+(ProcessTracker\s+-\s+)?(\([^\)]+\)\s+)?IndexConfig/IndexConfig/g" \
@@ -6545,7 +6545,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This usually indicates a misconfigured serverclass.conf or a missing application from the deployment-apps directory")` \
+search = ```This usually indicates a misconfigured serverclass.conf or a missing application from the deployment-apps directory``` \
 index=_internal `deploymentserverhosts` "ERROR Serverclass" OR "ERROR DSManager" OR ("WARN  DeploymentServer") OR CASE(" FATAL ") OR (TERM(DS_DC_Common) NOT "attributes cannot be handled by WebUI") sourcetype=splunkd (`splunkadmins_splunkd_source`) \
 | cluster showcount=true \
 | table _time, _raw, cluster_count
@@ -6571,7 +6571,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("If the max_action_results is exceeded the alert action receives only part of the results to work with, this can be a problem with the lookup alert action or others...")` index=_internal `searchheadhosts` sourcetype=scheduler alert_actions!="" `splunkadmins_alertactions_max_action_results`\
+search = ```If the max_action_results is exceeded the alert action receives only part of the results to work with, this can be a problem with the lookup alert action or others...``` index=_internal `searchheadhosts` sourcetype=scheduler alert_actions!="" `splunkadmins_alertactions_max_action_results`\
     [| rest /services/configs/conf-limits `splunkadmins_restmacro` f=title f=max_action_results\
     | search title=scheduler\
     | eval search="result_count>" . max_action_results\
@@ -6652,8 +6652,8 @@ display.general.type = statistics
 enableSched = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("Attempt to determine index access via the remote_searches.log file, useful for when you cannot see the audit logs of all incoming search heads. This version looks for wildcards and it is not expected to be super-accurate, as while we can determine the incoming server, and sometimes the incoming user from the search id we cannot accurately determine the roles of the user without building yet more lookups and complexity. Therefore this search exists only to roughly summarize if an index was ever accessed via wildcards or not at the indexing tier")` \
-    index=_internal sourcetype=splunkd_remote_searches source="/opt/splunk/var/log/splunk/remote_searches.log" terminated: OR closed: `comment("Note that TERM(starting) has the apiStartTime, apiEndTime stats, but lacks the useful stats from a search that is complete. Also note that on indexers scan_count=events_count (in my testing). Finally the elapsedTime sometimes failed to auto-extract, perhaps due to length...")` \
+search = ```Attempt to determine index access via the remote_searches.log file, useful for when you cannot see the audit logs of all incoming search heads. This version looks for wildcards and it is not expected to be super-accurate, as while we can determine the incoming server, and sometimes the incoming user from the search id we cannot accurately determine the roles of the user without building yet more lookups and complexity. Therefore this search exists only to roughly summarize if an index was ever accessed via wildcards or not at the indexing tier``` \
+    index=_internal sourcetype=splunkd_remote_searches source="/opt/splunk/var/log/splunk/remote_searches.log" terminated: OR closed: ```Note that TERM(starting) has the apiStartTime, apiEndTime stats, but lacks the useful stats from a search that is complete. Also note that on indexers scan_count=events_count (in my testing). Finally the elapsedTime sometimes failed to auto-extract, perhaps due to length...``` \
 | rex "(?s) elapsedTime=(?P<elapsedTime>[0-9\.]+), search='(?P<search>.*?)(', savedsearch_name|\", drop_count=\d+)" \
 | regex search!="^(pretypeahead|copybuckets)" \
 | rex "drop_count=[0-9]+, scan_count=(?P<scan_count>[0-9]+)" \
@@ -6668,14 +6668,14 @@ search = `comment("Attempt to determine index access via the remote_searches.log
 | eval prepipe = prepipe . " " . subsearch \
 | eval search=prepipe \
 | rex mode=sed field=search "s/search index=\s*\S+\s+index\s*=/search index=/g" \
-| search `comment("Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements")` \
-| search `comment("The (index=* OR index=_*) index=<specific index> is a common use case for enterprise security, also some individuals like doing a similar trick so remove the index=*... as this is not a wildcard index search")` \
+| search ```Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements``` \
+| search ```The (index=* OR index=_*) index=<specific index> is a common use case for enterprise security, also some individuals like doing a similar trick so remove the index=*... as this is not a wildcard index search``` \
 | rex field=search "(?P<esstylewildcard>\(\s*index=_\*\s+OR\s+index=\*\s+\))" \
-| search `comment("Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements")` \
+| search ```Extract out index= or index IN (a,b,c) but avoid NOT index in (...) and NOT index=... and also NOT (...anything) statements``` \
 | rex field=search "(?s)(NOT\s+index(\s*=\s*|::)[^ ]+)|(NOT\s+\([^\)]+\))|(index(\s*=\s*|::)(?P<indexregex>[\*A-Za-z0-9-_]+))" max_match=50 \
 | rex field=search "(?s)(NOT\s+index(\s*=\s*|::)[^ ]+)|(NOT\s+\([^\)]+\))|(index(\s*=\s*|::)\"?(?P<indexregex2>[\*A-Za-z0-9-_]+))" max_match=50 \
 | rex field=search "\s+(?P<skipping>\.\.\.\{skipping \d+ bytes\}\.\.\.)" \
-| search `comment("If skipping is in the logs as in index=abc- ...{skipping 46464 bytes}..., then drop the last index found in the regex as it is likely invalid")` \
+| search ```If skipping is in the logs as in index=abc- ...{skipping 46464 bytes}..., then drop the last index found in the regex as it is likely invalid``` \
 | eval indexregex=if(isnotnull(skipping),mvindex(indexregex,0,-2),indexregex) \
 | eval indexregex2=if(isnotnull(skipping),mvindex(indexregex2,0,-2),indexregex2) \
 | eval indexes=mvappend(indexregex,indexregex2) \
@@ -6696,7 +6696,7 @@ search = `comment("Attempt to determine index access via the remote_searches.log
 | eval type=if(isnotnull(presummarize),"acceleration",type) \
 | eval search_head_cluster=`search_head_cluster` \
 | eval indexer_cluster=`indexer_cluster_name(host)` \
-| search `comment("If you use the TERM(starting) you get the apiStartTime/apiEndTime, or you could join them in stats or similar...however this works to obtain which indexes are used. Note that you would need to build something similar to 'SearchHeadLevel - Search Queries summary non-exact match' to be able to translate the wildcards into something more useful, but there would be a lot of guesswork involved if you do not have usernames+server names+roles...(which is why audit logs work better for this)")` \
+| search ```If you use the TERM(starting) you get the apiStartTime/apiEndTime, or you could join them in stats or similar...however this works to obtain which indexes are used. Note that you would need to build something similar to 'SearchHeadLevel - Search Queries summary non-exact match' to be able to translate the wildcards into something more useful, but there would be a lot of guesswork involved if you do not have usernames+server names+roles...(which is why audit logs work better for this)``` \
 | rex "search_rawdata_bucketcache_error=[^,]+, search_rawdata_bucketcache_miss=(?P<cache_rawdata_miss>[^,]+), search_index_bucketcache_error=[^,]+, search_index_bucketcache_hit=(?P<cache_index_hit>[^,]+), search_index_bucketcache_miss=(?P<cache_index_miss>[^,]+), search_rawdata_bucketcache_hit=(?P<cache_rawdata_hit>[^,]+), search_rawdata_bucketcache_miss_wait=(?P<cache_rawdata_miss_wait>[^,]+), search_index_bucketcache_miss_wait=(?P<cache_index_miss_wait>[^,]+)" \
 | `base64decode(base64appname)` \
 | eval app3="N/A"  \
@@ -6713,7 +6713,7 @@ search = `comment("Attempt to determine index access via the remote_searches.log
 | addinfo \
 | rename info_max_time AS _time \
 | fields - info_* \
-| search `comment("| mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, indexer_cluster, type, user, indexes, multi, short, app. Below is useful if you instead use summary indexing for metrics in newer Splunk versions...in Splunk 8.0.x delete the below lines")` \
+| search ```| mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, indexer_cluster, type, user, indexes, multi, short, app. Below is useful if you instead use summary indexing for metrics in newer Splunk versions...in Splunk 8.0.x delete the below lines``` \
 | rename * AS platform_stats.remote_searches.per_index.nonexact.* \
 | rename platform_stats.remote_searches.per_index.nonexact.search_head_cluster AS search_head_cluster platform_stats.remote_searches.per_index.nonexact.indexer_cluster AS indexer_cluster, platform_stats.remote_searches.per_index.nonexact.type AS type, platform_stats.remote_searches.per_index.nonexact.user AS user, platform_stats.remote_searches.per_index.nonexact.indexes AS indexes, platform_stats.remote_searches.per_index.nonexact.multi AS multi, platform_stats.remote_searches.per_index.nonexact.short AS short, platform_stats.remote_searches.per_index.nonexact.app AS app \
 | fields - prefix
@@ -6914,7 +6914,7 @@ search =  | rest /servicesNS/-/-/saved/searches timeout=900 `splunkadmins_restma
 | eval prefix="user_stats.savedsearches." \
 | eval _time=now() \
 | fields - info_*\
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, user, scheduled, app")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, user, scheduled, app```
 
 [SearchHeadLevel - platform_stats.users dashboards]
 action.email.useNSSubject = 1
@@ -6936,7 +6936,7 @@ search =  | rest /servicesNS/-/-/data/ui/views timeout=900 `splunkadmins_restmac
 | eval prefix="user_stats.dashboards." \
 | eval _time=now() \
 | fields - info_* \
-| search `comment("mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, user, app")`
+| search ```mcollect index=a_metrics_index split=true prefix_field=prefix search_head_cluster, user, app```
 
 [AllSplunkLevel - No recent metrics.log data]
 alert.severity = 4
@@ -6957,8 +6957,8 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | tstats prestats=t count where index=_internal `splunkenterprisehosts` `splunkadmins_metrics_source` by host, _time span=5m \
-`comment("This alert attempts to detect when a forwarder or Splunk server stops sending logs for an extended period of time outside a shutdown...")`\
-| search `comment("Exclude the shutdown times")` NOT \
+```This alert attempts to detect when a forwarder or Splunk server stops sending logs for an extended period of time outside a shutdown...```\
+| search ```Exclude the shutdown times``` NOT \
     [ `splunkadmins_shutdown_list(splunkenterprisehosts,30,30)`] \
 | timechart limit=0 aligntime=latest span=5m count by host \
 | fillnull \
@@ -6983,7 +6983,7 @@ enableSched = 0
 realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search =  `searchheadhosts` (index=_audit action=search search_id NOT typeahead NOT "search_id='rsa_*") `comment("Original version by Nico Van Der Walt, modified by Gareth Anderson")` \
+search =  `searchheadhosts` (index=_audit action=search search_id NOT typeahead NOT "search_id='rsa_*") ```Original version by Nico Van Der Walt, modified by Gareth Anderson``` \
 invocations_command_search_index_bucketcache_miss>0 OR invocations_command_search_rawdata_bucketcache_miss>0 TERM(info=*) TERM(UI:Dashboard:*) \
 | eval total_days_searched=(search_lt-search_et)/86400 \
 | eval total_hours_searched=total_days_searched*24 \
@@ -7037,7 +7037,7 @@ enableSched = 0
 realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search =  `searchheadhosts` (index=_audit action=search search_id NOT typeahead NOT "search_id='rsa_*") `comment("Original version by Nico Van Der Walt, modified by Gareth Anderson")`\
+search =  `searchheadhosts` (index=_audit action=search search_id NOT typeahead NOT "search_id='rsa_*") ```Original version by Nico Van Der Walt, modified by Gareth Anderson```\
 invocations_command_search_index_bucketcache_miss>0 OR invocations_command_search_rawdata_bucketcache_miss>0 TERM(info=*) TERM(UI:Search) \
 | eval total_days_searched=(search_lt-search_et)/86400 \
 | eval total_hours_searched=total_days_searched*24 \
@@ -7093,7 +7093,7 @@ enableSched = 0
 realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search =  `searchheadhosts` (index=_audit action=search search_id NOT typeahead NOT "search_id='rsa_*") `comment("Original version by Nico Van Der Walt, modified by Gareth Anderson")`\
+search =  `searchheadhosts` (index=_audit action=search search_id NOT typeahead NOT "search_id='rsa_*") ```Original version by Nico Van Der Walt, modified by Gareth Anderson```\
 invocations_command_search_index_bucketcache_miss>0 OR invocations_command_search_rawdata_bucketcache_miss>0 TERM(info=*) TERM(UI:Dashboard:*) OR TERM(UI:Search) \
 | eval total_days_searched=(search_lt-search_et)/86400 \
 | eval total_hours_searched=total_days_searched*24 \
@@ -7151,7 +7151,7 @@ enableSched = 0
 realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search =  index=_internal `indexerhosts` sourcetype=splunkd_remote_searches StreamedSearch Streamed search connection terminated: OR closed: search_id=* `indexerhosts` rawdata_bucketcache_miss>0 OR index_bucketcache_miss>0 `comment("based on a search from Richard Morgan's dashboard, https://github.com/silkyrich/cluster_health_tools/blob/master/default/data/ui/views/debug_cache_manager_misses.xml")` \
+search =  index=_internal `indexerhosts` sourcetype=splunkd_remote_searches StreamedSearch Streamed search connection terminated: OR closed: search_id=* `indexerhosts` rawdata_bucketcache_miss>0 OR index_bucketcache_miss>0 ```based on a search from Richard Morgan's dashboard, https://github.com/silkyrich/cluster_health_tools/blob/master/default/data/ui/views/debug_cache_manager_misses.xml``` \
 | rex field=_raw "search_rawdata_bucketcache_error=(?<rawdata_bucketcache_error>[\d.]+)" \
 | rex field=_raw "search_rawdata_bucketcache_miss=(?<rawdata_bucketcache_miss>[\d.]+)" \
 | rex field=_raw "search_index_bucketcache_error=(?<index_bucketcache_error>[\d.]+)" \
@@ -7254,7 +7254,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("attempt to detect overuse of the REST API by non-system users")` index=_internal `searchheadhosts` sourcetype=splunkd_access useragent!="Splunk/*" useragent!="Splunkd/*" user!=splunk-system-user user!=admin user!=- NOT "/results_preview" "/search/jobs/" clientip!="127.0.0.1" `comment("this is the splunk internal httplib version proxying requests on behalf of clients this will likely change on upgrade, current as of 8.2.2.1")` NOT (`splunkadmins_excessive_rest_api_httplib` "isProxyRequest=true")\
+search = ```attempt to detect overuse of the REST API by non-system users``` index=_internal `searchheadhosts` sourcetype=splunkd_access useragent!="Splunk/*" useragent!="Splunkd/*" user!=splunk-system-user user!=admin user!=- NOT "/results_preview" "/search/jobs/" clientip!="127.0.0.1" ```this is the splunk internal httplib version proxying requests on behalf of clients this will likely change on upgrade, current as of 8.2.2.1``` NOT (`splunkadmins_excessive_rest_api_httplib` "isProxyRequest=true")\
 | regex uri!="/control$" \
 | bin _time span=2m \
 | stats count by user, _time \
@@ -7283,7 +7283,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("this works except in 8.2.5 it's slower than stats... | tstats count where index=_internal `searchheadhosts` source=*scheduler.log sourcetype=scheduler by host, _time span=1m")` \
+search = ```this works except in 8.2.5 it's slower than stats... | tstats count where index=_internal `searchheadhosts` source=*scheduler.log sourcetype=scheduler by host, _time span=1m``` \
 index=_internal `searchheadhosts` source=*scheduler.log sourcetype=scheduler \
 | bin _time span=1m \
 | stats count by host, _time \
@@ -7291,7 +7291,7 @@ index=_internal `searchheadhosts` source=*scheduler.log sourcetype=scheduler \
 | fillnull \
 | untable _time, host, count \
 | stats max(_time) AS mostRecent, min(_time) AS firstSeen, last(count) AS lastCount by host \
-| search `comment("Exclude time periods where shutdowns were occurring")` AND NOT [`splunkadmins_shutdown_time(searchheadhosts,60,60)`] \
+| search ```Exclude time periods where shutdowns were occurring``` AND NOT [`splunkadmins_shutdown_time(searchheadhosts,60,60)`] \
 | where lastCount=0 \
 | eval logMessages="Zero log entries found at this time, this might be a Splunkd issue, please investigate" \
 | fields - lastCount \
@@ -7395,7 +7395,7 @@ display.visualizations.charting.chart = line
 display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = | rest `splunkadmins_restmacro` /services/search/distributed/peers `comment("Note that the replicationStatus is only valid when run from the SHC captain node")` \
+search = | rest `splunkadmins_restmacro` /services/search/distributed/peers ```Note that the replicationStatus is only valid when run from the SHC captain node``` \
 | rex field=bundle_isIndexing "\w\s-\s(?<isindexing>\w+)" \
 | eval latest_bundle=mvindex(bundle_versions,0), isindexing=mvindex(isindexing,0) \
 | table splunk_server host status version guid replicationStatus latest_bundle isindexing
@@ -7459,7 +7459,7 @@ display.visualizations.show = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
 search = | rest "/services/admin/introspection--disk-objects--summaries?count=-1" `splunkindexerhostsvalue` \
-| search `comment("If you want just a single datamodel you can do | tstats summariesonly=t count from datamodel=<datamodel> by index, remove the summariesonly=t to search non-accelerated. Finally | datamodel <datamodel> acceleration_search will show the accelerated search")` \
+| search ```If you want just a single datamodel you can do | tstats summariesonly=t count from datamodel=<datamodel> by index, remove the summariesonly=t to search non-accelerated. Finally | datamodel <datamodel> acceleration_search will show the accelerated search``` \
 | stats sum(total_size) AS total_size, sum(total_bucket_count) AS total_bucket_count, values(related_indexes) AS related_indexes by title, search_head_guid, type
 
 [SearchHeadLevel - Detect bundle pushes no longer occurring]
@@ -7565,7 +7565,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = index=_internal sourcetype=splunkd `splunkadmins_metrics_source` group=dutycycle `indexerhosts` thread=replicationdatareceiverthread `comment("if the replication data receiver thread is using close to 100% for longer than a short period of time it results in other indexers slowing down, and often the entire ingestion tier slowing down")` \
+search = index=_internal sourcetype=splunkd `splunkadmins_metrics_source` group=dutycycle `indexerhosts` thread=replicationdatareceiverthread ```if the replication data receiver thread is using close to 100% for longer than a short period of time it results in other indexers slowing down, and often the entire ingestion tier slowing down``` \
 | eval dutycycle_ratio_perc=(ratio * 100) \
 | bin _time span=5m \
 | stats avg(dutycycle_ratio_perc) AS avg_dutycycle_ratio_perc by host, _time \
@@ -7677,8 +7677,8 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("The indexer is freezing buckets due to disk space pressure before the frozenTimePeriodInSecs limit has been reached, this could be a problem if it is not expected...")`\
-`comment("_introspection defaults to size based so exclude it")` \
+search = ```The indexer is freezing buckets due to disk space pressure before the frozenTimePeriodInSecs limit has been reached, this could be a problem if it is not expected...```\
+```_introspection defaults to size based so exclude it``` \
 index=_internal `cluster_masters` sourcetype=splunkd (`splunkadmins_splunkd_source`) freezing reason NOT "exceeded frozenTimePeriodInSecs" \
 `splunkadmins_bucketfrozen`\
 | eval newestDataInBucket=strftime(bucket_latest , "%+"), oldestDataInBucket = strftime(bucket_earliest, "%+") \
@@ -7707,7 +7707,7 @@ quantity = 0
 relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This alert is created to check for any 500 or 503 error from the Smart Store/S3")`\
+search = ```This alert is created to check for any 500 or 503 error from the Smart Store/S3```\
     index=_internal sourcetype=splunkd `indexerhosts` `splunkadmins_splunkd_source` ( log_level=ERROR OR log_level=WARN ) S3Client \
 | cluster labelonly=true t=0.5\
 | stats earliest(_time) as FirstSeen, latest(_time) as LastSeen count, first(_raw) AS _raw by statusCode, cluster_label\
@@ -7759,7 +7759,7 @@ search = index=_internal `sysloghosts` statistics\
 [ eval <<FIELD>>diff='<<FIELD>>'-'prev_<<FIELD>>' ]\
 | fields - processed_center_received_diff\
 | timechart avg(*_diff) AS "*_diff" span=10m by host\
-| search `comment("At this point you probably want to do a | fields *d_syslog_output* or similar")`
+| search ```At this point you probably want to do a | fields *d_syslog_output* or similar```
 
 [SearchHeadLevel - Knowledge Bundle contents]
 action.email.useNSSubject = 1
@@ -7776,7 +7776,7 @@ display.general.type = statistics
 enableSched = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = `comment("This is an example of what the search looks like, remove the comment for this to work. Note that you can remove the bundle=computed so that you see the current bundle, computed is more useful if you cannot distribute the bundle due to size. | bundlefiles bundle=computed")` \
+search = ```This is an example of what the search looks like, remove the comment for this to work. Note that you can remove the bundle=computed so that you see the current bundle, computed is more useful if you cannot distribute the bundle due to size. | bundlefiles bundle=computed``` \
 | sort 0 - bytes \
 | eval MB=round(bytes/1024/1024) \
 | eventstats sum(bytes) AS total_kv_mb by kvstore_collection, kvstore_app \
@@ -8184,7 +8184,7 @@ relation = greater than
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search 
 search = index=_internal sourcetype=splunkd source=*splunkd.log* `searchheadhosts` "Connect Timeout" OR "Unable to get authentication token" component IN (DistributedPeer, GetRemoteAuthToken) \
-| search `comment("Exclude time periods where shutdowns were occurring including 10 minutes after shutdown to handle any reboot time")` AND NOT \
+| search ```Exclude time periods where shutdowns were occurring including 10 minutes after shutdown to handle any reboot time``` AND NOT \
  [ `splunkadmins_shutdown_time(indexerhosts,60,600)`] \
 | bin _time span=5m \
 | rex "(?P<peerinfo>peer:\s|Peer:.*)" \
@@ -8485,7 +8485,7 @@ enableSched = 0
 realtime_schedule = 0
 request.ui_dispatch_app = SplunkAdmins
 request.ui_dispatch_view = search
-search = index=_internal `indexerhosts` sourcetype=splunkd_remote_searches source="/opt/splunk/var/log/splunk/remote_searches.log" terminated: OR closed: `comment("Note that keyword starting has the apiStartTime, apiEndTime stats, but lacks the useful stats from a search that is complete. Also note that on indexers scan_count=events_count (in my testing). Finally the elapsedTime sometimes failed to auto-extract, perhaps due to length...")`\
+search = index=_internal `indexerhosts` sourcetype=splunkd_remote_searches source="/opt/splunk/var/log/splunk/remote_searches.log" terminated: OR closed: ```Note that keyword starting has the apiStartTime, apiEndTime stats, but lacks the useful stats from a search that is complete. Also note that on indexers scan_count=events_count (in my testing). Finally the elapsedTime sometimes failed to auto-extract, perhaps due to length...```\
 | regex search!="^(pretypeahead|copybuckets)"\
 | regex search!="^presummarize (tstats=t maintain=\"\" summaryprefix=\"[^\"]+\"|maintain=\"%22SUMMARY_ID%22%2C%22EARLIEST_TIME%22%2C%22REMOTE_SEARCH%22%2C%22NORM_SUMMARY_ID%22%2C%22NORM_REMOTE_SEARCH%22%0A\" summaryprefix=\"[^\"]+\")\s*$"\
 | rex "(terminated|closed): search_id=(?P<search_id>[^,]+)"\


### PR DESCRIPTION
The comment macro was replaced by Splunk with 'triple backticks' formatting in version 8.1 - which was deemed end-of-life in April 2023.
The changes included here update comment macro references in savedsearches.conf, macros.conf, and a handful of dashboards.

